### PR TITLE
Claude commands for setup a dev environment and debugging the operator locally

### DIFF
--- a/.claude/commands/debug-operator.md
+++ b/.claude/commands/debug-operator.md
@@ -1,0 +1,109 @@
+# Debug NetObserv Operator Locally
+
+This command prepares the environment for debugging the operator locally.
+
+**Prerequisites:** You must have already set up the development environment using `/setup-dev-env` before running this command.
+
+## Steps
+
+### 1. Scale down the in-cluster operator
+
+Scale down the operator running in the cluster to avoid conflicts:
+
+```bash
+kubectl scale deployment netobserv-controller-manager -n netobserv --replicas=0
+```
+
+### 2. Remove the validating webhook
+
+Delete the webhook to allow free modification of the FlowCollector CR during local development:
+
+```bash
+kubectl delete validatingwebhookconfiguration netobserv-validating-webhook-configuration
+```
+
+### 3. Run the operator locally
+
+Use the AskUserQuestion tool to ask which debugging method to use:
+
+**Question:** "How do you want to run the operator locally?"
+- **Header:** "Debug method"
+- **Options:**
+  1. "go run - Simple execution without debugging"
+  2. "delve interactive - Terminal debugging with dlv commands"
+  3. "delve headless + VSCode - UI debugging with breakpoints"
+
+**Based on the user's selection, execute the corresponding command:**
+
+#### Option 1: go run
+```bash
+go run ./main.go \
+  -ebpf-agent-image=quay.io/netobserv/netobserv-ebpf-agent:main \
+  -flowlogs-pipeline-image=quay.io/netobserv/flowlogs-pipeline:main \
+  -console-plugin-image=quay.io/netobserv/network-observability-console-plugin:main \
+  -namespace=netobserv
+```
+
+#### Option 2: delve interactive
+```bash
+dlv debug ./main.go -- \
+  -ebpf-agent-image=quay.io/netobserv/netobserv-ebpf-agent:main \
+  -flowlogs-pipeline-image=quay.io/netobserv/flowlogs-pipeline:main \
+  -console-plugin-image=quay.io/netobserv/network-observability-console-plugin:main \
+  -namespace=netobserv
+```
+
+After starting, inform the user they can use these delve commands:
+- `break main.main` - set breakpoint
+- `continue` - continue execution
+- `next` - step to next line
+- `print <variable>` - inspect variables
+
+#### Option 3: delve headless + VSCode
+
+**Step 1:** Start Delve in headless mode:
+```bash
+dlv debug ./main.go --headless --listen=:2345 --api-version=2 --accept-multiclient -- \
+  -ebpf-agent-image=quay.io/netobserv/netobserv-ebpf-agent:main \
+  -flowlogs-pipeline-image=quay.io/netobserv/flowlogs-pipeline:main \
+  -console-plugin-image=quay.io/netobserv/network-observability-console-plugin:main \
+  -namespace=netobserv
+```
+
+**Step 2:** Inform the user:
+
+"Delve is now running in headless mode on port 2345. To connect from VSCode:
+1. Open the Debug view (Ctrl+Shift+D / Cmd+Shift+D)
+2. Select 'Connect to Delve (Operator Debug)' from the dropdown
+3. Press F5 or click 'Start Debugging'
+
+You can now set breakpoints in VSCode and debug the operator."
+
+### 4. Example: Debug FlowCollector reconciliation
+
+**To help the user get started with debugging:**
+
+The main reconciliation logic is in `internal/controller/flowcollector/flowcollector_controller.go` (look for the `Reconcile` function around line 100-150).
+
+**If using VSCode debugging:**
+1. Open `internal/controller/flowcollector/flowcollector_controller.go`
+2. Click the left margin next to the line number inside the `Reconcile` function to set a breakpoint
+3. Trigger a reconciliation by running:
+```bash
+kubectl patch flowcollector cluster --type=merge -p '{"spec":{"processor":{"logLevel":"debug"}}}'
+```
+
+The debugger will pause at your breakpoint, allowing you to inspect the FlowCollector object and step through the reconciliation logic.
+
+## Cleanup
+
+When finished debugging:
+
+1. Stop the local operator (Ctrl+C in terminal, or stop debugging in VSCode)
+
+2. Scale the in-cluster operator back up:
+```bash
+kubectl scale deployment netobserv-controller-manager -n netobserv --replicas=1
+```
+
+**Note:** The validating webhook will be automatically recreated by the operator.

--- a/.claude/commands/setup-dev-env.md
+++ b/.claude/commands/setup-dev-env.md
@@ -1,0 +1,79 @@
+# Setup NetObserv Development Environment
+
+This command sets up a complete development environment for NetObserv.
+
+## Gather Configuration
+
+First, use the AskUserQuestion tool to gather the necessary configuration:
+
+**Question 1:** What platform are you using?
+- Options: OpenShift, Kubernetes
+- Header: "Platform"
+- Store the answer to determine if `make set-release-kind-downstream` should be run in step 2.
+
+**Question 2:** Are you using custom images?
+- Options: "Yes, custom images", "No, use defaults (netobserv/main)"
+- Header: "Images"
+
+**If the user selected custom images**, ask follow-up questions to get:
+- USER (quay.io username/repo, e.g., "leandroberetta")
+- VERSION (image tag, e.g., "v1.2.3" or "main")
+
+Set the variables:
+- If using defaults: `USER=netobserv` and `VERSION=main`
+- If using custom: `USER=<user_value>` and `VERSION=<version_value>`
+
+## Steps
+
+### 1. Deploy the operator
+
+Run the deployment command with the configured values:
+
+**If custom USER and VERSION:**
+```bash
+USER=<user_value> VERSION=<version_value> make deploy
+```
+
+**If using defaults:**
+```bash
+USER=netobserv make deploy
+```
+
+### 2. Configure for OpenShift (if applicable)
+
+**Only run this if the user selected OpenShift** in the platform question:
+
+```bash
+make set-release-kind-downstream
+```
+
+Skip this step for Kubernetes.
+
+### 3. Deploy Loki
+
+```bash
+make deploy-loki
+```
+
+### 4. Deploy sample FlowCollector CR
+
+```bash
+make deploy-sample-cr
+```
+
+### 5. Verify deployment
+
+Run these commands to verify all components are running:
+
+```bash
+kubectl get pods -n netobserv
+kubectl get flowcollector cluster -o yaml
+```
+
+## Cleanup
+
+To remove the entire environment:
+
+```bash
+make undeploy
+```

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Connect to Delve (Operator Debug)",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "remotePath": "${workspaceFolder}",
+            "port": 2345,
+            "host": "localhost",
+            "showLog": true,
+            "trace": "verbose"
+        }
+    ]
+}


### PR DESCRIPTION
## Description

 This PR adds Claude commands to streamline the development workflow for NetObserv contributors.

  ### Commands Added

  #### `/setup-dev-env` - Setup NetObserv Development Environment
  Sets up a complete development environment with interactive configuration:
  - Prompts for platform selection (OpenShift or Kubernetes)
  - Asks about custom images vs defaults
  - Deploys the operator with proper configuration
  - Deploys Loki and sample FlowCollector CR
  - Verifies the deployment

  **Usage:** Ask Claude "Setup NetObserv Development Environment" or use `/setup-dev-env`

  #### `/debug-operator` - Debug NetObserv Operator Locally
  Prepares the environment for local debugging with multiple debugging options:
  - Scales down in-cluster operator
  - Removes validating webhook
  - Prompts for debugging method (go run, delve interactive, or delve headless + VSCode)
  - Provides guidance for setting breakpoints in the FlowCollector reconciler
  - Includes cleanup instructions

  **Usage:** Ask Claude "Debug NetObserv Operator Locally" or use `/debug-operator`

  ### Key Features

  - **Interactive Configuration**: Commands use Claude's `AskUserQuestion` tool to gather user
  preferences
  - **Multiple Debugging Options**: Supports different workflows (simple execution, terminal
  debugging, VSCode debugging)
  - **Clear Prerequisites**: `/debug-operator` requires `/setup-dev-env` to be run first
  - **Cleanup Instructions**: Both commands include cleanup steps
  - **VSCode Integration**: Added `.vscode/launch.json` for seamless Delve debugging

  ### Benefits

  - Reduces onboarding time for new contributors
  - Standardizes development environment setup
  - Simplifies local debugging workflow
  - Eliminates the need to remember complex command sequences


## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labeled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
