### PR TITLE
NETOBSERV-2872 change feature columns defaults for views

### DIFF
--- a/internal/controller/consoleplugin/config/static-frontend-config.yaml
+++ b/internal/controller/consoleplugin/config/static-frontend-config.yaml
@@ -175,7 +175,7 @@ columns:
     tooltip: Network name, such as Secondary network or UDN.
     field: SrcK8S_NetworkName
     filter: src_network
-    default: true
+    default: false
     width: 15
     feature: multiNetworks
   - id: DstK8S_Name
@@ -316,7 +316,7 @@ columns:
     tooltip: Network name, such as Secondary network or UDN.
     field: DstK8S_NetworkName
     filter: dst_network
-    default: true
+    default: false
     width: 15
     feature: multiNetworks
   - id: K8S_Name
@@ -437,7 +437,7 @@ columns:
     tooltip: TLS version found in handshake headers
     field: TLSVersion
     filter: tls_version
-    default: true
+    default: false
     width: 10
     feature: tlsTracking
   - id: TLSCipherSuite
@@ -611,7 +611,7 @@ columns:
     tooltip: Time elapsed between DNS request and response.
     field: DnsLatencyMs
     filter: dns_latency
-    default: true
+    default: false
     width: 5
     feature: dnsTracking
   - id: DNSResponseCode
@@ -620,7 +620,7 @@ columns:
     tooltip: DNS RCODE name from response header.
     field: DnsFlagsResponseCode
     filter: dns_flag_response_code
-    default: true
+    default: false
     width: 5
     feature: dnsTracking
   - id: DNSErrNo
@@ -637,7 +637,7 @@ columns:
     tooltip: TCP Smoothed Round Trip Time (SRTT)
     field: TimeFlowRttNs
     filter: time_flow_rtt
-    default: true
+    default: false
     width: 5
     feature: flowRTT
   - id: NetworkEvents
@@ -645,7 +645,7 @@ columns:
     tooltip: Network events flow monitor
     field: NetworkEvents
     filter: network_events
-    default: true
+    default: false
     width: 15
     feature: networkEvents
   - id: XlatZoneId
@@ -653,7 +653,7 @@ columns:
     name: Xlat zone id
     field: ZoneId
     filter: xlat_zone_id
-    default: true
+    default: false
     width: 5
     feature: packetTranslation
   - id: XlatSrcAddr
@@ -678,7 +678,7 @@ columns:
     group: Xlat
     name: Xlat Src Kubernetes Object
     calculated: kubeObject(XlatSrcK8S_Type,XlatSrcK8S_Namespace,XlatSrcK8S_Name,1) or concat(XlatSrcAddr,':',XlatSrcPort)
-    default: true
+    default: false
     width: 15
     feature: packetTranslation
   - id: XlatDstAddr
@@ -703,7 +703,7 @@ columns:
     group: Xlat
     name: Xlat Dst Kubernetes Object
     calculated: kubeObject(XlatDstK8S_Type,XlatDstK8S_Namespace,XlatDstK8S_Name,1) or concat(XlatDstAddr,':',XlatDstPort)
-    default: true
+    default: false
     width: 15
     feature: packetTranslation
   - id: XlatK8S_Object
@@ -718,7 +718,7 @@ columns:
     tooltip: Status of the IPsec encryption (on egress, provided by the kernel function xfrm_output) or decryption (on ingress, via xfrm_input).
     field: IPSecStatus
     filter: ipsec_status
-    default: true
+    default: false
     width: 10
     feature: ipsec
 filters:


### PR DESCRIPTION
## Description

change feature columns defaults for views now since those columns will be preset in feature specific view and All Traffic column will only show default base columns.


## Dependencies

https://github.com/netobserv/netobserv-web-console/pull/1595


## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

Co-Authored-By: Claude Sonnet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Updated default network and connection table settings to show fewer columns initially.
  * Applied consistent defaults across source and destination network details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->