### PR TITLE
NETOBSERV-2575: Add unit test for removal of tolerations

### DIFF
--- a/internal/controller/envtest/flowcollector_controller_console_envtest.go
+++ b/internal/controller/envtest/flowcollector_controller_console_envtest.go
@@ -322,6 +322,33 @@ func FlowCollectorConsolePluginSpecs(env test.Environment, ctxGetter test.Contex
 					return nil
 				}, timeout, interval).Should(Succeed())
 			})
+
+			It("Should clear toleration config when subscription config is removed", func() {
+				Eventually(func() interface{} {
+					subs := olm.Subscription{}
+					if err := k8sClient.Get(ctx, subscriptionKey, &subs); err != nil {
+						return err
+					}
+					subs.Spec.Config = nil
+					return k8sClient.Update(ctx, &subs)
+				}, timeout, interval).Should(Succeed())
+			})
+
+			It("Should remove toleration and nodeSelector from static plugin deployment", func() {
+				Eventually(func() interface{} {
+					dp := appsv1.Deployment{}
+					if err := k8sClient.Get(ctx, staticCpKey, &dp); err != nil {
+						return err
+					}
+					if len(dp.Spec.Template.Spec.Tolerations) != 0 {
+						return fmt.Errorf("expected no tolerations, got: %v", dp.Spec.Template.Spec.Tolerations)
+					}
+					if len(dp.Spec.Template.Spec.NodeSelector) != 0 {
+						return fmt.Errorf("expected no node selector, got: %v", dp.Spec.Template.Spec.NodeSelector)
+					}
+					return nil
+				}, timeout, interval).Should(Succeed())
+			})
 		})
 	}
 


### PR DESCRIPTION
## Description

Additional unit tests to check removal of tolerations for StaticPlugin

## Dependencies

n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added OpenShift environment coverage verifying that clearing subscription scheduling configuration removes associated tolerations and node selectors from the console plugin deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->