### PR TITLE
NETOBSERV-2890: reconcile ConsolePlugin upon change

### DIFF
--- a/internal/controller/consoleplugin/consoleplugin_reconciler.go
+++ b/internal/controller/consoleplugin/consoleplugin_reconciler.go
@@ -25,9 +25,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-// Type alias
-type pluginSpec = flowslatest.FlowCollectorConsolePlugin
-
 // CPReconciler reconciles the current console plugin state with the desired configuration
 type CPReconciler struct {
 	*reconcilers.Instance
@@ -109,7 +106,7 @@ func (r *CPReconciler) reconcile(ctx context.Context, desired *flowslatest.FlowC
 		}
 
 		if hasPluginAPI {
-			if err = r.reconcilePlugin(ctx, &builder, &desired.Spec, constants.PluginName, "NetObserv plugin"); err != nil {
+			if err = r.reconcilePlugin(ctx, &builder, constants.PluginName, "NetObserv plugin"); err != nil {
 				return err
 			}
 		}
@@ -210,8 +207,10 @@ func (r *CPReconciler) reconcilePermissions(ctx context.Context, builder *builde
 	return nil
 }
 
-func (r *CPReconciler) reconcilePlugin(ctx context.Context, builder *builder, desired *flowslatest.FlowCollectorSpec, name, displayName string) error {
-	// Console plugin is cluster-scope (it's not deployed in our namespace) however it must still be updated if our namespace changes
+func (r *CPReconciler) reconcilePlugin(ctx context.Context, builder *builder, name, displayName string) error {
+	report := helper.NewChangeReport("ConsolePlugin")
+	defer report.LogIfNeeded(ctx)
+
 	oldPlg := osv1.ConsolePlugin{}
 	pluginExists := true
 	err := r.Get(ctx, types.NamespacedName{Name: name}, &oldPlg)
@@ -229,7 +228,7 @@ func (r *CPReconciler) reconcilePlugin(ctx context.Context, builder *builder, de
 		if err := r.CreateOwned(ctx, consolePlugin); err != nil {
 			return err
 		}
-	} else if pluginNeedsUpdate(&oldPlg, &desired.ConsolePlugin) {
+	} else if helper.ConsolePluginChanged(&oldPlg, consolePlugin, &report) {
 		if err := r.UpdateIfOwned(ctx, &oldPlg, consolePlugin); err != nil {
 			return err
 		}
@@ -311,11 +310,6 @@ func (r *CPReconciler) reconcileHPA(ctx context.Context, builder *builder, desir
 		&desired.ConsolePlugin.Autoscaler,
 		&report,
 	)
-}
-
-func pluginNeedsUpdate(plg *osv1.ConsolePlugin, desired *pluginSpec) bool {
-	advancedConfig := helper.GetAdvancedPluginConfig(desired.Advanced)
-	return plg.Spec.Backend.Service.Port != *advancedConfig.Port
 }
 
 // getExternalRecordingAnnotations reads PrometheusRules with label netobserv=true and netobserv.io/network-health annotation.

--- a/internal/controller/consoleplugin/consoleplugin_static_reconciler.go
+++ b/internal/controller/consoleplugin/consoleplugin_static_reconciler.go
@@ -86,7 +86,7 @@ func (r *StaticReconciler) reconcileStatic(ctx context.Context, desired *flowsla
 		// Create object builder
 		builder := newBuilder(r.Instance, &desired.Spec, constants.StaticPluginName)
 
-		if err = r.reconcilePlugin(ctx, &builder, &desired.Spec, constants.StaticPluginName, "NetObserv static plugin"); err != nil {
+		if err = r.reconcilePlugin(ctx, &builder, constants.StaticPluginName, "NetObserv static plugin"); err != nil {
 			return err
 		}
 

--- a/internal/pkg/helper/comparators.go
+++ b/internal/pkg/helper/comparators.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	osv1 "github.com/openshift/api/console/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	ascv2 "k8s.io/api/autoscaling/v2"
@@ -156,6 +157,10 @@ func PrometheusRuleChanged(old, n *monitoringv1.PrometheusRule, report *ChangeRe
 	// Note: DeepDerivative misses changes in Spec.Groups.Rules (covered by test "Expecting PrometheusRule to exist and be updated")
 	return report.Check("PrometheusRule spec changed", !deepEqual(n.Spec, old.Spec)) ||
 		report.Check("PrometheusRule labels changed", !IsSubSet(old.Labels, n.Labels))
+}
+
+func ConsolePluginChanged(old, n *osv1.ConsolePlugin, report *ChangeReport) bool {
+	return report.Check("ConsolePlugin spec changed", !deepDerivative(n.Spec, old.Spec))
 }
 
 // FindContainer searches in pod containers one that matches the provided name


### PR DESCRIPTION
## Description

Reconcile ConsolePlugin upon change
Previously, it was only reconciled when backend port was changed, and nothing else.

(small fix for a non-user-facing issue, marking no-qe)

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how console plugin updates are detected, reducing unnecessary refreshes and making changes apply more reliably.
  * Updated reconciliation behavior so existing console plugin settings are compared more accurately before deciding to update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->