### PR TITLE
Auto update image digest in helm charts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          persist-credentials: false
+          fetch-depth: 0
 
       - name: validate tag
         run: |
@@ -116,6 +116,27 @@ jobs:
           subject-digest: ${{ env.digest }}
           sbom-path: './release-assets/sbom.spdx.json'
           push-to-registry: true
+
+      - name: update Helm image digest
+        run: |
+          git fetch origin main
+          git checkout main
+          git pull --ff-only origin main
+
+          yq -i '.operator.digest = "${{ env.digest }}"' helm/values.yaml
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add helm/values.yaml
+
+          if git diff --cached --quiet; then
+            echo "Helm values already contain this digest"
+            exit 0
+          fi
+
+          git commit -m "chore: update operator image digest to ${{ env.digest }}"
+          git push origin main
 
       - name: create draft release and upload binaries
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: '{{ .Values.operator.image }}:{{ .Values.operator.version }}'
+          image: "{{ .Values.operator.image }}{{ if .Values.operator.digest }}@{{ .Values.operator.digest }}{{ else }}:{{ .Values.operator.version }}{{ end }}"
           imagePullPolicy: Always
           livenessProbe:
             httpGet:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -24,6 +24,7 @@ standaloneConsole:
 operator:
   image: quay.io/netobserv/network-observability-operator
   version: 1.12.0-community
+  digest: ""
   # Node affinity configuration for the operator deployment
   nodeAffinity: {}
   # Example:


### PR DESCRIPTION
## Description

Using also the image digest name instead of just image version in helm charts. Updated the ".github/workflows/release.yml" file.
1. Created new job "name: update Helm image digest".
2. Updated  `persist-credentials: false` to `fetch-depth: 0` during checkout.
3. Added `digest: ""` in operator spec in values.yaml file.
4. Updated `image` spec in "helm/templates/deployment.yaml" to use `digest` or `tag` as required.
# Dependencies
solves: https://github.com/netobserv/netobserv-operator/issues/2850 after https://github.com/netobserv/netobserv-operator/issues/2490.
<!-- List here any related PRs with links, that need to be pulled also for testing -->

<!-- ## Checklist

 If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. 

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team). -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional image digest pinning for the operator deployment.
  * Added configuration support for specifying an operator image digest.

* **Improvements**
  * Release automation now records the built image digest automatically when it changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->