### PR TITLE
NETOBSERV-2877: setup required annotations for openshift pods

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,7 @@ linters:
     - unused
   settings:
     cyclop:
-      max-complexity: 20
+      max-complexity: 24
     gocritic:
       enabled-checks:
         - hugeParam

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ endif
 # Image URL to use all building/pushing image targets
 IMAGE ?= $(IMAGE_TAG_BASE):$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
+# When updating, update also SetupKubeBuilderAssets in internal/pkg/test/envtest.go
 ENVTEST_K8S_VERSION = 1.23
 GOLANGCI_LINT_VERSION = v2.12.2
 CRDOC_VERSION = 0.6.4

--- a/bundles/k8s/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundles/k8s/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -1056,6 +1056,7 @@ spec:
                     path: /healthz
                     port: 8081
                   periodSeconds: 10
+                terminationMessagePolicy: FallbackToLogsOnError
                 volumeMounts:
                 - mountPath: /tmp/k8s-webhook-server/serving-certs
                   name: cert

--- a/bundles/openshift/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundles/openshift/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -91,7 +91,7 @@ metadata:
     categories: Monitoring, Networking, Observability
     console.openshift.io/plugins: '["netobserv-plugin"]'
     containerImage: quay.io/netobserv/network-observability-operator:1.12.0-community
-    createdAt: "2026-07-21T07:39:53Z"
+    createdAt: "2026-08-12T16:15:17Z"
     description: Network flows collector and monitoring solution
     operatorframework.io/initialization-resource: '{"apiVersion":"flows.netobserv.io/v1beta2",
       "kind":"FlowCollector","metadata":{"name":"cluster"},"spec": {}}'
@@ -985,6 +985,8 @@ spec:
           strategy: {}
           template:
             metadata:
+              annotations:
+                openshift.io/required-scc: restricted-v2
               labels:
                 app: netobserv-operator
                 control-plane: controller-manager
@@ -1056,6 +1058,7 @@ spec:
                     path: /healthz
                     port: 8081
                   periodSeconds: 10
+                terminationMessagePolicy: FallbackToLogsOnError
                 volumeMounts:
                 - mountPath: /tmp/k8s-webhook-server/serving-certs
                   name: cert

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -82,5 +82,6 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/openshift/common/manager-patch.yaml
+++ b/config/openshift/common/manager-patch.yaml
@@ -4,6 +4,11 @@
   value: manager
 
 - op: add
+  path: "/spec/template/metadata/annotations"
+  value:
+    openshift.io/required-scc: restricted-v2
+
+- op: add
   path: "/spec/template/spec/volumes/-"
   value:
     name: manager-metric-tls

--- a/internal/controller/consoleplugin/consoleplugin_convergence_test.go
+++ b/internal/controller/consoleplugin/consoleplugin_convergence_test.go
@@ -1,0 +1,99 @@
+package consoleplugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	flowslatest "github.com/netobserv/netobserv-operator/api/flowcollector/v1beta2"
+	"github.com/netobserv/netobserv-operator/internal/controller/constants"
+	"github.com/netobserv/netobserv-operator/internal/pkg/helper"
+	"github.com/netobserv/netobserv-operator/internal/pkg/test"
+)
+
+// TestBuiltObjectsConvergeAgainstAPIServer guards against the whole "reconcile never converges" bug
+// family, at the level of the objects the operator builds (Deployment, Service, ...). It is the
+// object-level counterpart of the CR-level isomorphism test in flowcollector_controller_iso_envtest.go.
+//
+// The pitfall: the builder leaves a field empty (e.g. the static plugin leaves ImagePullPolicy unset,
+// because its faked FlowCollector never goes through OpenAPI defaulting). The API server then defaults
+// the *stored* object (ImagePullPolicy -> IfNotPresent). If the comparator exact-compares such a field,
+// it reports a phantom change on every reconcile and issues a redundant Update forever - which, once the
+// object is also watched, turns into an update/conflict storm.
+//
+// This test builds objects exactly as the reconciler does, round-trips them through a real API server so
+// they get the same defaulting, then asserts the operator's own comparator sees no change. It is a
+// catch-all: any comparator-inspected field that the builder leaves for the API server to default (now or
+// in the future) will fail here, not only ImagePullPolicy.
+func TestBuiltObjectsConvergeAgainstAPIServer(t *testing.T) {
+	assert := assert.New(t)
+
+	err := test.SetupKubeBuilderAssets()
+	require.NoError(t, err)
+
+	testEnv := &envtest.Environment{}
+	cfg, err := testEnv.Start()
+	require.NoError(t, err)
+	defer func() { _ = testEnv.Stop() }()
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	require.NoError(t, err)
+
+	// Load the CRD so the builder resolves the same OpenAPI defaults (e.g. the plugin port) it would in
+	// production, instead of zero values.
+	require.NoError(t, helper.SetCRDForTests(test.RepoRoot()))
+
+	ctx := context.Background()
+	require.NoError(t, k8sClient.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: testNamespace},
+	}))
+
+	// Build objects with minimal values to trigger API server defaults as much as possible.
+	spec := flowslatest.FlowCollectorSpec{
+		Namespace: testNamespace,
+		ConsolePlugin: flowslatest.FlowCollectorConsolePlugin{
+			Enable: ptr.To(true),
+		},
+	}
+	loki := helper.LokiConfig{
+		LokiManualParams: flowslatest.LokiManualParams{IngesterURL: "http://loki:3100/", TenantID: "netobserv"},
+	}
+	builder := getBuilder(&spec, &loki)
+
+	// Deployment
+	{
+		require.NoError(t, k8sClient.Create(ctx, builder.deployment(constants.PluginName, "digest")))
+		stored := appsv1.Deployment{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: constants.PluginName, Namespace: testNamespace}, &stored))
+
+		desired := builder.deployment(constants.PluginName, "digest") // fresh, un-mutated by the API server
+		report := helper.NewChangeReport("")
+		assert.False(
+			helper.DeploymentChanged(&stored, desired, constants.PluginName, &report),
+			"Deployment does not converge against API-server defaults; reconcile would loop. Report: %s", report.String(),
+		)
+	}
+
+	// Service
+	{
+		require.NoError(t, k8sClient.Create(ctx, builder.mainService(constants.PluginName)))
+		stored := corev1.Service{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: constants.PluginName, Namespace: testNamespace}, &stored))
+
+		desired := builder.mainService(constants.PluginName)
+		report := helper.NewChangeReport("")
+		assert.False(
+			helper.ServiceChanged(&stored, desired, &report),
+			"Service does not converge against API-server defaults; reconcile would loop. Report: %s", report.String(),
+		)
+	}
+}

--- a/internal/controller/consoleplugin/consoleplugin_objects.go
+++ b/internal/controller/consoleplugin/consoleplugin_objects.go
@@ -186,7 +186,6 @@ func (b *builder) deployment(name, cmDigest string) *appsv1.Deployment {
 }
 
 func (b *builder) podTemplate(name, cmDigest string) *corev1.PodTemplateSpec {
-	var sa string
 	annotations := map[string]string{}
 	args := []string{
 		"-loglevel", b.desired.ConsolePlugin.LogLevel,
@@ -194,8 +193,11 @@ func (b *builder) podTemplate(name, cmDigest string) *corev1.PodTemplateSpec {
 	volumes := []corev1.Volume{}
 	volumeMounts := []corev1.VolumeMount{}
 
+	if b.info.ClusterInfo.IsOpenShift() {
+		annotations[constants.OpenShiftReqSCCAnnotation] = constants.OpenShiftReqSCCAnnotationDefaultValue
+	}
+
 	if cmDigest != "" {
-		sa = name
 		annotations[constants.PodConfigurationDigest] = cmDigest
 
 		args = append(args, "-config", filepath.Join(configPath, configFile))
@@ -241,17 +243,18 @@ func (b *builder) podTemplate(name, cmDigest string) *corev1.PodTemplateSpec {
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{
-				Name:            name,
-				Image:           b.info.Images[b.imageRef],
-				ImagePullPolicy: corev1.PullPolicy(b.desired.ConsolePlugin.ImagePullPolicy),
-				Resources:       *b.desired.ConsolePlugin.Resources.DeepCopy(),
-				VolumeMounts:    b.volumes.AppendMounts(volumeMounts),
-				Env:             helper.AppendTLSEnvVars([]corev1.EnvVar{constants.EnvNoHTTP2}, b.info.TLSConfig),
-				Args:            args,
-				SecurityContext: helper.ContainerDefaultSecurityContext(),
+				Name:                     name,
+				Image:                    b.info.Images[b.imageRef],
+				ImagePullPolicy:          corev1.PullPolicy(b.desired.ConsolePlugin.ImagePullPolicy),
+				Resources:                *b.desired.ConsolePlugin.Resources.DeepCopy(),
+				VolumeMounts:             b.volumes.AppendMounts(volumeMounts),
+				Env:                      helper.AppendTLSEnvVars([]corev1.EnvVar{constants.EnvNoHTTP2}, b.info.TLSConfig),
+				Args:                     args,
+				SecurityContext:          helper.ContainerDefaultSecurityContext(),
+				TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 			}},
 			Volumes:            b.volumes.AppendVolumes(volumes),
-			ServiceAccountName: sa,
+			ServiceAccountName: name,
 			NodeSelector:       b.advanced.Scheduling.NodeSelector,
 			Tolerations:        b.advanced.Scheduling.Tolerations,
 			Affinity:           b.advanced.Scheduling.Affinity,

--- a/internal/controller/consoleplugin/consoleplugin_static_reconciler.go
+++ b/internal/controller/consoleplugin/consoleplugin_static_reconciler.go
@@ -92,6 +92,12 @@ func (r *StaticReconciler) reconcileStatic(ctx context.Context, desired *flowsla
 		// Create object builder
 		builder := newBuilder(r.Instance, &desired.Spec, constants.StaticPluginName)
 
+		if !r.Managed.Exists(r.serviceAccount) {
+			if err = r.CreateOwned(ctx, builder.serviceAccount(constants.StaticPluginName)); err != nil {
+				return err
+			}
+		}
+
 		if err = r.reconcileStaticPlugin(ctx, &builder, constants.StaticPluginName); err != nil {
 			return err
 		}

--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -39,7 +39,9 @@ const (
 	EBPFSecurityContext               = EBPFAgentName
 	EBPFMetricPort                    = 9400
 
-	OpenShiftCertificateAnnotation = "service.beta.openshift.io/serving-cert-secret-name"
+	OpenShiftCertificateAnnotation        = "service.beta.openshift.io/serving-cert-secret-name"
+	OpenShiftReqSCCAnnotation             = "openshift.io/required-scc"
+	OpenShiftReqSCCAnnotationDefaultValue = "restricted-v2"
 
 	// PodConfigurationDigest is an annotation name to facilitate pod restart after
 	// any external configuration change

--- a/internal/controller/ebpf/agent_controller.go
+++ b/internal/controller/ebpf/agent_controller.go
@@ -263,6 +263,9 @@ func (c *AgentController) desired(ctx context.Context, coll *flowslatest.FlowCol
 	rlog := log.FromContext(ctx).WithName("ebpf")
 	version := helper.ExtractVersion(c.Images[reconcilers.MainImage])
 	annotations := make(map[string]string)
+	if c.ClusterInfo.IsOpenShift() {
+		annotations[constants.OpenShiftReqSCCAnnotation] = constants.EBPFSecurityContext
+	}
 	env, err := c.envConfig(ctx, coll, annotations)
 	if err != nil {
 		return nil, err
@@ -441,13 +444,14 @@ func (c *AgentController) desired(ctx context.Context, coll *flowslatest.FlowCol
 					DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
 					Volumes:            volumes,
 					Containers: []corev1.Container{{
-						Name:            constants.EBPFAgentName,
-						Image:           c.Images[reconcilers.MainImage],
-						ImagePullPolicy: corev1.PullPolicy(coll.Spec.Agent.EBPF.ImagePullPolicy),
-						Resources:       coll.Spec.Agent.EBPF.Resources,
-						SecurityContext: c.securityContext(coll),
-						Env:             env,
-						VolumeMounts:    volumeMounts,
+						Name:                     constants.EBPFAgentName,
+						Image:                    c.Images[reconcilers.MainImage],
+						ImagePullPolicy:          corev1.PullPolicy(coll.Spec.Agent.EBPF.ImagePullPolicy),
+						Resources:                coll.Spec.Agent.EBPF.Resources,
+						SecurityContext:          c.securityContext(coll),
+						Env:                      env,
+						VolumeMounts:             volumeMounts,
+						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 					}},
 					NodeSelector:      advancedConfig.Scheduling.NodeSelector,
 					Tolerations:       advancedConfig.Scheduling.Tolerations,

--- a/internal/controller/ebpf/internal/permissions/permissions.go
+++ b/internal/controller/ebpf/internal/permissions/permissions.go
@@ -142,8 +142,7 @@ func (c *Reconciler) reconcileVendorPermissions(
 func (c *Reconciler) reconcileOpenshiftPermissions(
 	ctx context.Context, desired *flowslatest.FlowCollectorEBPF,
 ) error {
-	rlog := log.FromContext(ctx,
-		"securityContextConstraints", constants.EBPFSecurityContext)
+	rlog := log.FromContext(ctx, "securityContextConstraints", constants.EBPFSecurityContext)
 	scc := &osv1.SecurityContextConstraints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: constants.EBPFSecurityContext,

--- a/internal/controller/envtest/flowcollector_controller_certificates_envtest.go
+++ b/internal/controller/envtest/flowcollector_controller_certificates_envtest.go
@@ -298,7 +298,12 @@ func FlowCollectorCertificatesSpecs(env test.Environment, ctxGetter test.Context
 				}
 				return test.VolumeNames(plugin.Spec.Template.Spec.Volumes)
 			}, timeout, interval).Should(ContainElements(expectedVolumes))
-			Expect(plugin.Spec.Template.Annotations).To(HaveLen(1))
+			expectedAnnotLen := 1
+			if env == test.EnvOpenShift {
+				// In OpenShift, pods come with more annotations
+				expectedAnnotLen = 2
+			}
+			Expect(plugin.Spec.Template.Annotations).To(HaveLen(expectedAnnotLen))
 
 			By("Expecting Loki and Kafka certificates for FLP mounted")
 			Eventually(func() interface{} {

--- a/internal/controller/envtest/flowcollector_controller_console_envtest.go
+++ b/internal/controller/envtest/flowcollector_controller_console_envtest.go
@@ -14,6 +14,7 @@ import (
 	ascv2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -126,20 +127,21 @@ func FlowCollectorConsolePluginSpecs(env test.Environment, ctxGetter test.Contex
 		})
 	})
 
-	// Add Tests for OpenAPI validation (or additonal CRD features) specified in
-	// your API definition.
-	// Avoid adding tests for vanilla CRUD operations because they would
-	// test Kubernetes API server, which isn't the goal here.
 	Context("Deploying the console plugin", func() {
 		It("Should create successfully", func() {
 			By("Expecting to create the console plugin Deployment")
+			dp := appsv1.Deployment{}
 			Eventually(func() interface{} {
-				dp := appsv1.Deployment{}
 				if err := k8sClient.Get(ctx, cpKey, &dp); err != nil {
 					return err
 				}
 				return *dp.Spec.Replicas
 			}, timeout, interval).Should(Equal(int32(1)))
+
+			if env == test.EnvOpenShift {
+				By("In OpenShift, expecting to have the required SCC annotation")
+				Expect(dp.Spec.Template.Annotations).To(HaveKeyWithValue("openshift.io/required-scc", "restricted-v2"))
+			}
 
 			By("Expecting to create the console plugin Service")
 			Eventually(func() interface{} {
@@ -217,6 +219,46 @@ func FlowCollectorConsolePluginSpecs(env test.Environment, ctxGetter test.Contex
 						Namespace: cpNamespace,
 					}, &sm)
 				}, timeout, interval).Should(Succeed())
+			})
+		}
+	})
+
+	Context("FlowCollector status", func() {
+		It("Should have console ready status", func() {
+			// Manually set deployment ready
+			dp := appsv1.Deployment{}
+			Eventually(func() interface{} { return k8sClient.Get(ctx, cpKey, &dp) }, timeout, interval).Should(Succeed())
+			dp.Status.AvailableReplicas = 1
+			dp.Status.ReadyReplicas = 1
+			dp.Status.Replicas = 1
+			dp.Status.UpdatedReplicas = 1
+			Eventually(func() interface{} { return k8sClient.Status().Update(ctx, &dp) }, timeout, interval).Should(Succeed())
+
+			Eventually(func() interface{} {
+				fc := test.GetCR(ctx, k8sClient, crKey)
+				return meta.FindStatusCondition(fc.Status.Conditions, "WaitingWebConsole")
+			}, timeout, interval).Should(Satisfy(func(c *metav1.Condition) bool {
+				return c != nil && c.Status == metav1.ConditionFalse && c.Reason == "Ready"
+			}))
+		})
+
+		if env == test.EnvOpenShift {
+			It("Should have static plugin ready status", func() {
+				// Manually set deployment ready
+				dp := appsv1.Deployment{}
+				Eventually(func() interface{} { return k8sClient.Get(ctx, staticCpKey, &dp) }, timeout, interval).Should(Succeed())
+				dp.Status.AvailableReplicas = 1
+				dp.Status.ReadyReplicas = 1
+				dp.Status.Replicas = 1
+				dp.Status.UpdatedReplicas = 1
+				Eventually(func() interface{} { return k8sClient.Status().Update(ctx, &dp) }, timeout, interval).Should(Succeed())
+
+				Eventually(func() interface{} {
+					fc := test.GetCR(ctx, k8sClient, crKey)
+					return meta.FindStatusCondition(fc.Status.Conditions, "WaitingStaticController")
+				}, timeout, interval).Should(Satisfy(func(c *metav1.Condition) bool {
+					return c != nil && c.Status == metav1.ConditionFalse && c.Reason == "Ready"
+				}))
 			})
 		}
 	})

--- a/internal/controller/envtest/flowcollector_controller_console_envtest.go
+++ b/internal/controller/envtest/flowcollector_controller_console_envtest.go
@@ -245,18 +245,23 @@ func FlowCollectorConsolePluginSpecs(env test.Environment, ctxGetter test.Contex
 		if env == test.EnvOpenShift {
 			It("Should have static plugin ready status", func() {
 				// Manually set deployment ready
-				dp := appsv1.Deployment{}
-				Eventually(func() interface{} { return k8sClient.Get(ctx, staticCpKey, &dp) }, timeout, interval).Should(Succeed())
-				dp.Status.AvailableReplicas = 1
-				dp.Status.ReadyReplicas = 1
-				dp.Status.Replicas = 1
-				dp.Status.UpdatedReplicas = 1
-				Eventually(func() interface{} { return k8sClient.Status().Update(ctx, &dp) }, timeout, interval).Should(Succeed())
+				Eventually(func() interface{} {
+					dp := appsv1.Deployment{}
+					err := k8sClient.Get(ctx, staticCpKey, &dp)
+					if err != nil {
+						return err
+					}
+					dp.Status.AvailableReplicas = 1
+					dp.Status.ReadyReplicas = 1
+					dp.Status.Replicas = 1
+					dp.Status.UpdatedReplicas = 1
+					return k8sClient.Status().Update(ctx, &dp)
+				}, timeout, interval).Should(Succeed())
 
 				Eventually(func() interface{} {
 					fc := test.GetCR(ctx, k8sClient, crKey)
 					return meta.FindStatusCondition(fc.Status.Conditions, "WaitingStaticController")
-				}, timeout, interval).Should(Satisfy(func(c *metav1.Condition) bool {
+				}, 3*timeout /*might take longer than usual*/, interval).Should(Satisfy(func(c *metav1.Condition) bool {
 					return c != nil && c.Status == metav1.ConditionFalse && c.Reason == "Ready"
 				}))
 			})

--- a/internal/controller/envtest/flowcollector_controller_ebpf_envtest.go
+++ b/internal/controller/envtest/flowcollector_controller_ebpf_envtest.go
@@ -21,7 +21,7 @@ import (
 	"github.com/netobserv/netobserv-operator/internal/pkg/test"
 )
 
-func FlowCollectorEBPFSpecs(ctxGetter test.ContextGetter) {
+func FlowCollectorEBPFSpecs(env test.Environment, ctxGetter test.ContextGetter) {
 	var ctx context.Context
 	var k8sClient client.Client
 	BeforeEach(func() {
@@ -130,6 +130,11 @@ func FlowCollectorEBPFSpecs(ctxGetter test.ContextGetter) {
 			}
 			Expect(hostFound).To(BeTrue(),
 				fmt.Sprintf("expected TARGET_HOST env var in %+v", spec.Containers[0].Env))
+
+			if env == test.EnvOpenShift {
+				By("In OpenShift, expecting to have the required SCC annotation")
+				Expect(ds.Spec.Template.Annotations).To(HaveKeyWithValue("openshift.io/required-scc", "netobserv-ebpf-agent"))
+			}
 
 			ns := v1.Namespace{}
 			By("expecting to create the netobserv-privileged namespace")

--- a/internal/controller/envtest/openshift/suite_test.go
+++ b/internal/controller/envtest/openshift/suite_test.go
@@ -25,8 +25,6 @@ var (
 )
 
 func TestAPIsOpenShift(t *testing.T) {
-	// Uncomment and edit next line to run/debug from IDE (get the path by running: `bin/setup-envtest use 1.23 -p path`); you may need to override the test timeout in your settings.
-	// os.Setenv("KUBEBUILDER_ASSETS", "/home/jotak/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Controller Suite - OpenShift")
 }
@@ -36,7 +34,7 @@ func TestAPIsOpenShift(t *testing.T) {
 var _ = Describe("FlowCollector Controller - OpenShift", Ordered, Serial, func() {
 	ctxGetter := func() (context.Context, client.Client) { return ctx, k8sClient }
 	envtest.FlowCollectorConsolePluginSpecs(env, ctxGetter)
-	envtest.FlowCollectorEBPFSpecs(ctxGetter)
+	envtest.FlowCollectorEBPFSpecs(env, ctxGetter)
 	envtest.FlowCollectorEBPFKafkaSpecs(ctxGetter)
 	envtest.FlowCollectorMinimalSpecs(ctxGetter)
 	envtest.FlowCollectorIsoSpecs(ctxGetter)
@@ -56,7 +54,6 @@ var _ = BeforeSuite(func() {
 			"kafka-exporter-namespace",
 			"main-namespace-privileged",
 		},
-		"../..",
 	)
 })
 

--- a/internal/controller/envtest/vanilla/suite_test.go
+++ b/internal/controller/envtest/vanilla/suite_test.go
@@ -25,8 +25,6 @@ var (
 )
 
 func TestAPIsVanilla(t *testing.T) {
-	// Uncomment and edit next line to run/debug from IDE (get the path by running: `bin/setup-envtest use 1.23 -p path`); you may need to override the test timeout in your settings.
-	// os.Setenv("KUBEBUILDER_ASSETS", "/home/jotak/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Controller Suite - Vanilla")
 }
@@ -36,7 +34,7 @@ func TestAPIsVanilla(t *testing.T) {
 var _ = Describe("FlowCollector Controller - Vanilla", Ordered, Serial, func() {
 	ctxGetter := func() (context.Context, client.Client) { return ctx, k8sClient }
 	envtest.FlowCollectorConsolePluginSpecs(env, ctxGetter)
-	envtest.FlowCollectorEBPFSpecs(ctxGetter)
+	envtest.FlowCollectorEBPFSpecs(env, ctxGetter)
 	envtest.FlowCollectorEBPFKafkaSpecs(ctxGetter)
 	envtest.FlowCollectorMinimalSpecs(ctxGetter)
 	envtest.FlowCollectorHoldModeSpecs(ctxGetter)
@@ -52,7 +50,6 @@ var _ = BeforeSuite(func() {
 			"kafka-exporter-namespace",
 			"main-namespace-privileged",
 		},
-		"../..",
 	)
 })
 

--- a/internal/controller/envtest/vanillafs/suite_test.go
+++ b/internal/controller/envtest/vanillafs/suite_test.go
@@ -25,8 +25,6 @@ var (
 )
 
 func TestAPIsVanillaFullStack(t *testing.T) {
-	// Uncomment and edit next line to run/debug from IDE (get the path by running: `bin/setup-envtest use 1.23 -p path`); you may need to override the test timeout in your settings.
-	// os.Setenv("KUBEBUILDER_ASSETS", "/home/jotak/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Controller Suite - Vanilla Full Stack")
 }
@@ -36,7 +34,7 @@ func TestAPIsVanillaFullStack(t *testing.T) {
 var _ = Describe("FlowCollector Controller - Vanilla Full Stack", Ordered, Serial, func() {
 	ctxGetter := func() (context.Context, client.Client) { return ctx, k8sClient }
 	envtest.FlowCollectorConsolePluginSpecs(env, ctxGetter)
-	envtest.FlowCollectorEBPFSpecs(ctxGetter)
+	envtest.FlowCollectorEBPFSpecs(env, ctxGetter)
 	envtest.FlowCollectorEBPFKafkaSpecs(ctxGetter)
 	envtest.FlowCollectorMinimalSpecs(ctxGetter)
 	envtest.FlowCollectorCertificatesSpecs(env, ctxGetter)
@@ -53,7 +51,6 @@ var _ = BeforeSuite(func() {
 			"kafka-exporter-namespace",
 			"main-namespace-privileged",
 		},
-		"../..",
 	)
 })
 

--- a/internal/controller/flp/envtest/flp_controller_envtest.go
+++ b/internal/controller/flp/envtest/flp_controller_envtest.go
@@ -127,6 +127,11 @@ func ControllerSpecs(env test.Environment, ctxGetter test.ContextGetter) {
 				return nil
 			}, timeout, interval).Should(Succeed())
 
+			if env == test.EnvOpenShift {
+				By("In OpenShift, expecting to have the required SCC annotation")
+				Expect(ds.Spec.Template.Annotations).To(HaveKeyWithValue("openshift.io/required-scc", "hostnetwork"))
+			}
+
 			By("Expecting to create the flowlogs-pipeline-informers Deployment")
 			Eventually(func() interface{} {
 				deploy := appsv1.Deployment{}
@@ -318,10 +323,16 @@ func ControllerSpecs(env test.Environment, ctxGetter test.ContextGetter) {
 		})
 
 		It("Should deploy kafka transformer", func() {
+			var dp appsv1.Deployment
 			By("Expecting transformer deployment to be created")
 			Eventually(func() interface{} {
-				return k8sClient.Get(ctx, flpKeyKafkaTransformer, &appsv1.Deployment{})
+				return k8sClient.Get(ctx, flpKeyKafkaTransformer, &dp)
 			}, timeout, interval).Should(Succeed())
+
+			if env == test.EnvOpenShift {
+				By("In OpenShift, expecting to have the required SCC annotation")
+				Expect(dp.Spec.Template.Annotations).To(HaveKeyWithValue("openshift.io/required-scc", "restricted-v2"))
+			}
 
 			By("Not expecting transformer service (k8scache has its own dedicated service)")
 			Eventually(func() error {

--- a/internal/controller/flp/envtest/openshift/suite_test.go
+++ b/internal/controller/flp/envtest/openshift/suite_test.go
@@ -26,8 +26,6 @@ var (
 )
 
 func TestAPIsOpenShift(t *testing.T) {
-	// Uncomment and edit next line to run/debug from IDE (get the path by running: `bin/setup-envtest use 1.23 -p path`); you may need to override the test timeout in your settings.
-	// os.Setenv("KUBEBUILDER_ASSETS", "/home/jotak/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "FLP Controller Suite - OpenShift")
 }
@@ -46,7 +44,6 @@ var _ = BeforeSuite(func() {
 		[]manager.Registerer{flp.Start},
 		"main-namespace",
 		[]string{"other-namespace"},
-		"../../..",
 	)
 })
 

--- a/internal/controller/flp/envtest/vanilla/suite_test.go
+++ b/internal/controller/flp/envtest/vanilla/suite_test.go
@@ -26,8 +26,6 @@ var (
 )
 
 func TestAPIsVanilla(t *testing.T) {
-	// Uncomment and edit next line to run/debug from IDE (get the path by running: `bin/setup-envtest use 1.23 -p path`); you may need to override the test timeout in your settings.
-	// os.Setenv("KUBEBUILDER_ASSETS", "/home/jotak/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "FLP Controller Suite - Vanilla")
 }
@@ -46,7 +44,6 @@ var _ = BeforeSuite(func() {
 		[]manager.Registerer{flp.Start},
 		"main-namespace",
 		[]string{"other-namespace"},
-		"../../..",
 	)
 })
 

--- a/internal/controller/flp/envtest/vanillafs/suite_test.go
+++ b/internal/controller/flp/envtest/vanillafs/suite_test.go
@@ -26,8 +26,6 @@ var (
 )
 
 func TestAPIsVanillaFullStack(t *testing.T) {
-	// Uncomment and edit next line to run/debug from IDE (get the path by running: `bin/setup-envtest use 1.23 -p path`); you may need to override the test timeout in your settings.
-	// os.Setenv("KUBEBUILDER_ASSETS", "/home/jotak/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "FLP Controller Suite - Vanilla Full Stack")
 }
@@ -46,7 +44,6 @@ var _ = BeforeSuite(func() {
 		[]manager.Registerer{flp.Start},
 		"main-namespace",
 		[]string{"other-namespace"},
-		"../../..",
 	)
 })
 

--- a/internal/controller/flp/flp_common_objects.go
+++ b/internal/controller/flp/flp_common_objects.go
@@ -187,15 +187,16 @@ func podTemplate(
 		},
 	}})
 	container := corev1.Container{
-		Name:            constants.FLPName,
-		Image:           imageName,
-		ImagePullPolicy: corev1.PullPolicy(desired.Processor.ImagePullPolicy),
-		Args:            args,
-		Resources:       *desired.Processor.Resources.DeepCopy(),
-		VolumeMounts:    volumeMounts,
-		Ports:           ports,
-		Env:             envs,
-		SecurityContext: helper.ContainerDefaultSecurityContext(),
+		Name:                     constants.FLPName,
+		Image:                    imageName,
+		ImagePullPolicy:          corev1.PullPolicy(desired.Processor.ImagePullPolicy),
+		Args:                     args,
+		Resources:                *desired.Processor.Resources.DeepCopy(),
+		VolumeMounts:             volumeMounts,
+		Ports:                    ports,
+		Env:                      envs,
+		SecurityContext:          helper.ContainerDefaultSecurityContext(),
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
 	if *advancedConfig.EnableKubeProbes {
 		container.LivenessProbe = &corev1.Probe{

--- a/internal/controller/flp/flp_informer_builder.go
+++ b/internal/controller/flp/flp_informer_builder.go
@@ -208,12 +208,13 @@ func (b *informerBuilder) deployment() (*appsv1.Deployment, error) {
 				},
 			},
 		},
-		Ports:           ports,
-		VolumeMounts:    (&vols).GetMounts(),
-		Resources:       resources,
-		LivenessProbe:   livenessProbe,
-		ReadinessProbe:  readinessProbe,
-		SecurityContext: helper.ContainerDefaultSecurityContext(),
+		Ports:                    ports,
+		VolumeMounts:             (&vols).GetMounts(),
+		Resources:                resources,
+		LivenessProbe:            livenessProbe,
+		ReadinessProbe:           readinessProbe,
+		SecurityContext:          helper.ContainerDefaultSecurityContext(),
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 	}
 
 	// Get processor advanced scheduling configuration to apply to informers

--- a/internal/controller/flp/flp_monolith_objects.go
+++ b/internal/controller/flp/flp_monolith_objects.go
@@ -58,6 +58,7 @@ func (b *monolithBuilder) daemonSet(annotations map[string]string) *appsv1.Daemo
 	netType := hostNetwork
 	if b.info.ClusterInfo.IsOpenShift() {
 		netType = hostPort
+		annotations[constants.OpenShiftReqSCCAnnotation] = "hostnetwork"
 	}
 	pod := podTemplate(
 		monoName,
@@ -91,6 +92,9 @@ func (b *monolithBuilder) daemonSet(annotations map[string]string) *appsv1.Daemo
 }
 
 func (b *monolithBuilder) deployment(annotations map[string]string) *appsv1.Deployment {
+	if b.info.ClusterInfo.IsOpenShift() {
+		annotations[constants.OpenShiftReqSCCAnnotation] = constants.OpenShiftReqSCCAnnotationDefaultValue
+	}
 	pod := podTemplate(
 		monoName,
 		b.version,

--- a/internal/controller/flp/flp_transfo_objects.go
+++ b/internal/controller/flp/flp_transfo_objects.go
@@ -54,6 +54,9 @@ func newTransfoBuilder(info *reconcilers.Instance, desired *flowslatest.FlowColl
 }
 
 func (b *transfoBuilder) deployment(annotations map[string]string) *appsv1.Deployment {
+	if b.info.ClusterInfo.IsOpenShift() {
+		annotations[constants.OpenShiftReqSCCAnnotation] = constants.OpenShiftReqSCCAnnotationDefaultValue
+	}
 	pod := podTemplate(
 		transfoName,
 		b.version,

--- a/internal/controller/monitoring/suite_test.go
+++ b/internal/controller/monitoring/suite_test.go
@@ -20,8 +20,6 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	// Uncomment and edit next line to run/debug from IDE (get the path by running: `bin/setup-envtest use 1.23 -p path`); you may need to override the test timeout in your settings.
-	// os.Setenv("KUBEBUILDER_ASSETS", "/home/jotak/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Monitoring Controller Suite")
 }
@@ -38,7 +36,6 @@ var _ = BeforeSuite(func() {
 		[]manager.Registerer{Start},
 		"main-namespace",
 		[]string{"openshift-config-managed"},
-		"..",
 	)
 })
 

--- a/internal/controller/networkpolicy/envtest/openshift/suite_test.go
+++ b/internal/controller/networkpolicy/envtest/openshift/suite_test.go
@@ -27,8 +27,6 @@ var (
 )
 
 func TestAPIsOpenShift(t *testing.T) {
-	// Uncomment and edit next line to run/debug from IDE (get the path by running: `bin/setup-envtest use 1.23 -p path`); you may need to override the test timeout in your settings.
-	// os.Setenv("KUBEBUILDER_ASSETS", "/home/jotak/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Networkpolicy Controller Suite - OpenShift")
 }
@@ -46,7 +44,6 @@ var _ = BeforeSuite(func() {
 		[]manager.Registerer{static.Start, networkpolicy.Start},
 		"main-namespace",
 		[]string{"other-namespace", "main-namespace-privileged"},
-		"../../..",
 	)
 })
 

--- a/internal/controller/networkpolicy/envtest/vanilla/suite_test.go
+++ b/internal/controller/networkpolicy/envtest/vanilla/suite_test.go
@@ -27,8 +27,6 @@ var (
 )
 
 func TestAPIsVanilla(t *testing.T) {
-	// Uncomment and edit next line to run/debug from IDE (get the path by running: `bin/setup-envtest use 1.23 -p path`); you may need to override the test timeout in your settings.
-	// os.Setenv("KUBEBUILDER_ASSETS", "/home/jotak/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Networkpolicy Controller Suite - Vanilla")
 }
@@ -46,7 +44,6 @@ var _ = BeforeSuite(func() {
 		[]manager.Registerer{static.Start, networkpolicy.Start},
 		"main-namespace",
 		[]string{"other-namespace", "main-namespace-privileged"},
-		"../../..",
 	)
 })
 

--- a/internal/controller/networkpolicy/envtest/vanillafs/suite_test.go
+++ b/internal/controller/networkpolicy/envtest/vanillafs/suite_test.go
@@ -27,8 +27,6 @@ var (
 )
 
 func TestAPIsVanillaFullStack(t *testing.T) {
-	// Uncomment and edit next line to run/debug from IDE (get the path by running: `bin/setup-envtest use 1.23 -p path`); you may need to override the test timeout in your settings.
-	// os.Setenv("KUBEBUILDER_ASSETS", "/home/jotak/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Networkpolicy Controller Suite - Vanilla Full Stack")
 }
@@ -46,7 +44,6 @@ var _ = BeforeSuite(func() {
 		[]manager.Registerer{static.Start, networkpolicy.Start},
 		"main-namespace",
 		[]string{"other-namespace", "main-namespace-privileged"},
-		"../../..",
 	)
 })
 

--- a/internal/controller/static/static_controller.go
+++ b/internal/controller/static/static_controller.go
@@ -54,6 +54,15 @@ func Start(ctx context.Context, mgr *manager.Manager) (manager.PostCreateHook, e
 			reconcilers.IgnoreStatusChange,
 		).
 		Watches(
+			&appsv1.Deployment{},
+			handler.EnqueueRequestsFromMapFunc(func(_ context.Context, o client.Object) []reconcile.Request {
+				if o.GetNamespace() == mgr.Config.Namespace && o.GetName() == constants.StaticPluginName {
+					return []reconcile.Request{{NamespacedName: constants.FlowCollectorName}}
+				}
+				return nil
+			}),
+		).
+		Watches(
 			&networkingv1.NetworkPolicy{},
 			&handler.EnqueueRequestForObject{},
 			reconcilers.OperatorOwned(mgr.Config.Namespace),

--- a/internal/pkg/helper/comparators.go
+++ b/internal/pkg/helper/comparators.go
@@ -55,7 +55,7 @@ func DaemonSetChanged(current, desired *appsv1.DaemonSet) ReconcileAction {
 
 func DeploymentChanged(old, n *appsv1.Deployment, contName string, report *ChangeReport) bool {
 	return report.Check("Pod changed", PodChanged(&old.Spec.Template, &n.Spec.Template, contName, report)) ||
-		report.Check("Replicas changed", *old.Spec.Replicas != *n.Spec.Replicas)
+		report.Check("Replicas changed", n.Spec.Replicas != nil && *old.Spec.Replicas != *n.Spec.Replicas)
 }
 
 func PodChanged(old, n *corev1.PodTemplateSpec, containerName string, report *ChangeReport) bool {
@@ -130,7 +130,7 @@ func volumesChanged(old, n *corev1.PodTemplateSpec, report *ChangeReport) bool {
 
 func containerChanged(old, n *corev1.Container, report *ChangeReport) bool {
 	return report.Check("Image changed", n.Image != old.Image) ||
-		report.Check("Pull policy changed", n.ImagePullPolicy != old.ImagePullPolicy) ||
+		report.Check("Pull policy changed", n.ImagePullPolicy != "" && n.ImagePullPolicy != old.ImagePullPolicy) ||
 		report.Check("Args changed", !deepEqual(n.Args, old.Args)) ||
 		report.Check("Resources req/limit changed", !deepDerivative(n.Resources, old.Resources)) ||
 		report.Check("Env changed", !deepEqual(n.Env, old.Env)) ||

--- a/internal/pkg/manager/status/envtest/suite_test.go
+++ b/internal/pkg/manager/status/envtest/suite_test.go
@@ -20,8 +20,6 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
-	// Uncomment and edit next line to run/debug from IDE (get the path by running: `bin/setup-envtest use 1.23 -p path`); you may need to override the test timeout in your settings.
-	//	os.Setenv("KUBEBUILDER_ASSETS", "/home/jotak/.local/share/kubebuilder-envtest/k8s/1.23.5-linux-amd64")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "FlowCollector Status Test Suite")
 }
@@ -38,7 +36,6 @@ var _ = BeforeSuite(func() {
 		controllers.Registerers,
 		"main-namespace",
 		nil,
-		"../../..",
 	)
 })
 

--- a/internal/pkg/narrowcache/client.go
+++ b/internal/pkg/narrowcache/client.go
@@ -80,7 +80,7 @@ func (c *Client) getAndCreateWatchIfNeeded(ctx context.Context, info GVKInfo, gv
 
 	// Live query
 	rlog := log.FromContext(ctx).WithName("narrowcache").WithValues("objKey", objKey)
-	rlog.Info("Cache miss, doing live query")
+	rlog.V(1).Info("Cache miss, doing live query")
 	fetched, w, err := c.fetchAndWatch(ctx, objKey, info, key)
 	if err != nil {
 		return nil, objKey, err
@@ -129,7 +129,7 @@ func (c *Client) updateCache(ctx context.Context, cacheKey string, info GVKInfo,
 	rlog := log.FromContext(ctx).WithName("narrowcache")
 	defer func() {
 		watcher.Stop()
-		rlog.WithValues("key", cacheKey).Info("Watch terminated. Clearing cache entry.")
+		rlog.V(1).WithValues("key", cacheKey).Info("Watch terminated. Clearing cache entry.")
 		c.clearEntryByKey(cacheKey)
 	}()
 
@@ -141,7 +141,7 @@ func (c *Client) updateCache(ctx context.Context, cacheKey string, info GVKInfo,
 			if !ok {
 				// Watch channel closed (normal API timeout). Re-establish the watch
 				// to avoid losing handlers and missing subsequent events.
-				rlog.WithValues("key", cacheKey).Info("Watch channel closed, re-establishing")
+				rlog.V(1).WithValues("key", cacheKey).Info("Watch channel closed, re-establishing")
 				watcher.Stop()
 
 				obj, newWatcher, err := c.fetchAndWatch(ctx, cacheKey, info, objKey)
@@ -156,7 +156,7 @@ func (c *Client) updateCache(ctx context.Context, cacheKey string, info GVKInfo,
 				watcher = newWatcher
 				continue
 			}
-			rlog.WithValues("key", cacheKey, "event type", watchEvent.Type).Info("Event received")
+			rlog.V(1).WithValues("key", cacheKey, "event type", watchEvent.Type).Info("Event received")
 			if watchEvent.Type == watch.Added || watchEvent.Type == watch.Modified {
 				if err := c.setToCache(cacheKey, watchEvent.Object); err != nil {
 					rlog.WithValues("key", cacheKey).Error(err, "Error while updating cache")
@@ -249,7 +249,7 @@ func (c *Client) callHandlers(ctx context.Context, key string, ev watch.Event) {
 func (c *Client) GetSource(ctx context.Context, obj client.Object, h handler.EventHandler) (source.Source, error) {
 	// Prepare a Source and make sure it is associated with a watch
 	rlog := log.FromContext(ctx).WithName("narrowcache")
-	rlog.WithValues("name", obj.GetName(), "namespace", obj.GetNamespace()).Info("Getting Source:")
+	rlog.V(1).WithValues("name", obj.GetName(), "namespace", obj.GetNamespace()).Info("Getting Source:")
 	gvk, err := c.GroupVersionKindFor(obj)
 	if err != nil {
 		return nil, err
@@ -278,7 +278,7 @@ func (c *Client) clearEntry(ctx context.Context, obj client.Object) {
 	gvk, _ := c.GroupVersionKindFor(obj)
 	strGVK := gvk.String()
 	if _, managed := c.watchedGVKs[strGVK]; managed {
-		log.FromContext(ctx).
+		log.FromContext(ctx).V(1).
 			WithName("narrowcache").
 			WithValues("name", obj.GetName(), "namespace", obj.GetNamespace()).
 			Info("Invalidating cache entry")

--- a/internal/pkg/narrowcache/client_test.go
+++ b/internal/pkg/narrowcache/client_test.go
@@ -35,6 +35,7 @@ func (c *gvkClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersion
 
 func TestWatchReestablishment(t *testing.T) {
 	assert := assert.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "test-ns"},
@@ -53,15 +54,20 @@ func TestWatchReestablishment(t *testing.T) {
 		return true, watcher2, nil
 	})
 
+	newLiveClientBackup := NewLiveClient
 	NewLiveClient = func(_ *rest.Config) (kubernetes.Interface, error) {
 		return goclient, nil
 	}
+	t.Cleanup(func() {
+		cancel()
+		watcher1.Stop()
+		watcher2.Stop()
+		NewLiveClient = newLiveClientBackup
+	})
 	narrowCache := NewConfig(&rest.Config{}, ConfigMaps)
 	underlying := &gvkClient{}
 	nc, err := narrowCache.CreateClient(underlying)
 	assert.NoError(err)
-
-	ctx := context.Background()
 
 	// First Get: triggers live query + starts watch goroutine
 	out := &corev1.ConfigMap{}

--- a/internal/pkg/test/envtest.go
+++ b/internal/pkg/test/envtest.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"time"
 
 	//nolint:revive,staticcheck
@@ -71,23 +74,43 @@ type SuiteContext struct {
 
 type ContextGetter func() (context.Context, client.Client)
 
-func PrepareEnvTest(env Environment, controllers []manager.Registerer, opNamespace string, namespaces []string, basePath string) (context.Context, client.Client, *SuiteContext) {
+// SetupKubeBuilderAssets ensures KUBEBUILDER_ASSETS points at the envtest binaries, so tests that boot
+// an envtest.Environment can run standalone (e.g. plain `go test ./...`) and not only through `make test`.
+// If the variable is already set, it is left untouched.
+func SetupKubeBuilderAssets() error {
+	if os.Getenv("KUBEBUILDER_ASSETS") != "" {
+		return nil
+	}
+	root := RepoRoot()
+	// Calling setup-envtest which should be in this repo ./bin - if that's not the case, just run `make envtest` once and it should be downloaded.
+	// Make sure to always keep the version in sync with ENVTEST_K8S_VERSION in the Makefile.
+	out, err := exec.Command(filepath.Join(root, "bin", "setup-envtest"), "use", "1.23", "-p", "path").Output()
+	if err != nil {
+		return err
+	}
+	return os.Setenv("KUBEBUILDER_ASSETS", strings.TrimSpace(string(out)))
+}
+
+func PrepareEnvTest(env Environment, controllers []manager.Registerer, opNamespace string, namespaces []string) (context.Context, client.Client, *SuiteContext) {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 	ctx, cancel := context.WithCancel(context.TODO())
+	err := SetupKubeBuilderAssets()
+	Expect(err).NotTo(HaveOccurred())
 
 	By("bootstrapping test environment")
+	basePath := RepoRoot()
 	testEnv := &envtest.Environment{
 		Scheme: scheme.Scheme,
 		CRDInstallOptions: envtest.CRDInstallOptions{
 			Paths: []string{
 				// Hack to reintroduce when the API stored version != latest version: comment-out config/crd/bases and use hack instead; see also Makefile "hack-crd-for-test"
-				filepath.Join(basePath, "..", "..", "config", "crd", "bases"),
-				// filepath.Join(basePath, "..", "hack"),
+				filepath.Join(basePath, "config", "crd", "bases"),
+				// filepath.Join(basePath, "hack"),
 			},
 			CleanUpAfterUse: true,
 			WebhookOptions: envtest.WebhookInstallOptions{
 				Paths: []string{
-					filepath.Join(basePath, "..", "..", "config", "webhook"),
+					filepath.Join(basePath, "config", "webhook"),
 				},
 			},
 		},
@@ -97,14 +120,14 @@ func PrepareEnvTest(env Environment, controllers []manager.Registerer, opNamespa
 	case EnvOpenShift:
 		// We need to install the ConsolePlugin CRD to test setup of our Network Console Plugin
 		testEnv.CRDInstallOptions.Paths = append(testEnv.CRDInstallOptions.Paths,
-			filepath.Join(basePath, "..", "..", "vendor", "github.com", "openshift", "api", "console", "v1", "zz_generated.crd-manifests"),
-			filepath.Join(basePath, "..", "..", "vendor", "github.com", "openshift", "api", "config", "v1", "zz_generated.crd-manifests"),
-			filepath.Join(basePath, "..", "..", "vendor", "github.com", "openshift", "api", "operator", "v1", "zz_generated.crd-manifests"),
-			filepath.Join(basePath, "..", "..", "vendor", "github.com", "openshift", "api", "security", "v1", "zz_generated.crd-manifests"),
-			filepath.Join(basePath, "..", "..", "test-assets"),
+			filepath.Join(basePath, "vendor", "github.com", "openshift", "api", "console", "v1", "zz_generated.crd-manifests"),
+			filepath.Join(basePath, "vendor", "github.com", "openshift", "api", "config", "v1", "zz_generated.crd-manifests"),
+			filepath.Join(basePath, "vendor", "github.com", "openshift", "api", "operator", "v1", "zz_generated.crd-manifests"),
+			filepath.Join(basePath, "vendor", "github.com", "openshift", "api", "security", "v1", "zz_generated.crd-manifests"),
+			filepath.Join(basePath, "test-assets"),
 		)
 	case EnvVanillaFullStack:
-		testEnv.CRDInstallOptions.Paths = append(testEnv.CRDInstallOptions.Paths, filepath.Join(basePath, "..", "..", "test-assets"))
+		testEnv.CRDInstallOptions.Paths = append(testEnv.CRDInstallOptions.Paths, filepath.Join(basePath, "test-assets"))
 	case EnvVanillaNaked:
 		// nothing more
 	}
@@ -204,7 +227,7 @@ func PrepareEnvTest(env Environment, controllers []manager.Registerer, opNamespa
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sManager).NotTo(BeNil())
 
-	err = helper.SetCRDForTests(filepath.Join(basePath, "..", ".."))
+	err = helper.SetCRDForTests(filepath.Join(basePath))
 	Expect(err).NotTo(HaveOccurred())
 
 	createFakeController(ctx, k8sClient, opNamespace)
@@ -380,4 +403,14 @@ func Annotations(annots map[string]string) []string {
 		kv = append(kv, k+"="+v)
 	}
 	return kv
+}
+
+func RepoRoot() string {
+	// Resolve the repo root from this file's location, so it works regardless of the caller's cwd.
+	// This file lives at internal/pkg/test/envtest.go, i.e. three directories below the root.
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("RepoRoot: unable to resolve caller path")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
 }

--- a/internal/pkg/test/envtest.go
+++ b/internal/pkg/test/envtest.go
@@ -227,7 +227,7 @@ func PrepareEnvTest(env Environment, controllers []manager.Registerer, opNamespa
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sManager).NotTo(BeNil())
 
-	err = helper.SetCRDForTests(filepath.Join(basePath))
+	err = helper.SetCRDForTests(basePath)
 	Expect(err).NotTo(HaveOccurred())
 
 	createFakeController(ctx, k8sClient, opNamespace)


### PR DESCRIPTION
## Description

- Add `openshift.io/required-scc: restricted-v2` to all workloads
- Add static plugin service account

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved OpenShift compatibility by applying appropriate security context settings to managed workloads.
  * Improved container diagnostics by retaining termination details in logs when standard messages are unavailable.
  * Ensured console plugin service accounts are consistently configured and created when needed.
  * Improved deployment reconciliation by responding to managed deployment changes.
  * Improved cache reliability by restoring watches when connections close.

* **Bug Fixes**
  * Corrected security context and service account handling across managed deployments.
  * Updated release deployment metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->