### PR TITLE
NETOBSERV-2916: Fix secondary networks with informers

### DIFF
--- a/internal/controller/flp/flp_informer_builder.go
+++ b/internal/controller/flp/flp_informer_builder.go
@@ -2,6 +2,7 @@ package flp
 
 import (
 	"fmt"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -106,6 +107,20 @@ func (b *informerBuilder) deployment() (*appsv1.Deployment, error) {
 		// ManagedCNI: hardcoded to match flowlogs-pipeline default (config.go line 32)
 		// This ensures informers extract the same node IPs (e.g., OVN mp0) as processors
 		"--managed-cni=ovn",
+	}
+
+	// Propagate secondary networks config to informers (must match processor settings)
+	var secondaryIndexes []string
+	for _, sn := range b.desired.GetSecondaryIndexes() {
+		for _, index := range sn.Index {
+			secondaryIndexes = append(secondaryIndexes, strings.ToLower(string(index)))
+		}
+	}
+	if b.desired.Agent.EBPF.IsUDNMappingEnabled() {
+		secondaryIndexes = append(secondaryIndexes, "udn")
+	}
+	if len(secondaryIndexes) > 0 {
+		args = append(args, fmt.Sprintf("--secondary-networks=%s", strings.Join(secondaryIndexes, ",")))
 	}
 
 	// Add TLS configuration if enabled

--- a/internal/controller/flp/flp_informer_builder.go
+++ b/internal/controller/flp/flp_informer_builder.go
@@ -110,17 +110,22 @@ func (b *informerBuilder) deployment() (*appsv1.Deployment, error) {
 	}
 
 	// Propagate secondary networks config to informers (must match processor settings)
-	var secondaryIndexes []string
+	// Each index set is comma-separated, sets are semicolon-separated to preserve OR semantics
+	var snGroups []string
 	for _, sn := range b.desired.GetSecondaryIndexes() {
+		var indexes []string
 		for _, index := range sn.Index {
-			secondaryIndexes = append(secondaryIndexes, strings.ToLower(string(index)))
+			indexes = append(indexes, strings.ToLower(string(index)))
+		}
+		if len(indexes) > 0 {
+			snGroups = append(snGroups, strings.Join(indexes, ","))
 		}
 	}
 	if b.desired.Agent.EBPF.IsUDNMappingEnabled() {
-		secondaryIndexes = append(secondaryIndexes, "udn")
+		snGroups = append(snGroups, "udn")
 	}
-	if len(secondaryIndexes) > 0 {
-		args = append(args, fmt.Sprintf("--secondary-networks=%s", strings.Join(secondaryIndexes, ",")))
+	if len(snGroups) > 0 {
+		args = append(args, fmt.Sprintf("--secondary-networks=%s", strings.Join(snGroups, ";")))
 	}
 
 	// Add TLS configuration if enabled


### PR DESCRIPTION
## Description
Secondary networks enrichment is broken with FLP informers

## Dependencies
https://github.com/netobserv/flowlogs-pipeline/pull/1310

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

## Testing
 PASSED TESTS (1):
  ----------------------------------------------------------------------------------------------------------
  1. [sig-netobserv] Network_Observability Author:aramesha-High-81677-Validate UDN with NetObserv [Serial] [481.442 seconds]

   SUCCESS! 8m44.202616033s --- PASS: TestBackend (524.44s)
  PASS
  ok    e2etests        529.327s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring secondary networks in informer containers.
  * Secondary network names are normalized for consistent configuration.
  * Multiple secondary-network groups can be configured using comma- and semicolon-separated values.
  * UDN mapping is automatically included when enabled.
  * Secondary-network settings are applied only when configured, preserving existing behavior otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->