### PR TITLE
Re-establish narrowcache watches on API timeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,11 @@ Best practices for AI coding agents on NetObserv Operator.
 
 **Key Directories:**
 - `api/flowcollector/v1beta2/`: CRD definitions
-- `internal/controller/`: Reconciliation logic
+- `internal/controller/`: Reconciliation logic (main controller, static
+  controller, per-component sub-reconcilers)
+- `internal/pkg/narrowcache/`: Custom cache layer — watches only explicitly
+  requested objects instead of full GVKs, to limit memory in large clusters.
+  All controllers use it (via the manager client).
 - `config/`: Kustomize manifests
 - `docs/`: FlowCollector spec, architecture
 
@@ -39,7 +43,7 @@ if flowCollector.Name != constants.FlowCollectorName {
 ### 🚨 Backward Compatibility
 FlowCollector v1beta2 is stable:
 - ✅ Add optional fields, use `+optional` marker; defaults can be set either through OpenAPI or directly hardcoded, depending on how likely it is to change them in the future (a future change of OpenAPI-based default is ignored on installed operators being upgraded).
-- ❌ Never remove/rename fields or change types
+- ❌ Never remove/rename fields or change types. Deprecate them if necessary.
 
 ### 🚨 Bundle Updates Required
 After CRD/CSV changes: `make update-bundle`.
@@ -48,7 +52,7 @@ Generated files are:
 - Everything in `./bundles`
 - CRD references in `./docs` (e.g. `flowcollector-flows-netobserv-io-v1beta2` and `FlowCollector.md`)
 
-Do not manually edit any of those generated files, modify the source instead (e.g. `./config` (Kustomize) or in-code `kubebuilder` markers for CRD OpenAPI and bundle rbac).
+Do not manually edit any of those generated files, modify the source instead (e.g. `./config` (Kustomize) or in-code `kubebuilder` markers for CRD OpenAPI and bundle rbac). After running `make update-bundle`, the changes must be included in the commit.
 
 ### 🚨 Image References
 Never hardcode. Use env vars:
@@ -121,6 +125,12 @@ Files to modify:
 3. Rebuild: Changes are embedded at compile time via go:embed
 Note: Static config changes require operator rebuild/redeploy.
 ```
+
+### Controller Watch Patterns
+Any controller that creates Deployments or DaemonSets must watch them
+(e.g. `Owns(&appsv1.Deployment{})`) so it re-reconciles when their status
+changes. Without this, the controller will never detect that a resource
+became ready. See `flowcollector_controller.go` for the reference pattern.
 
 ## Code Review Checklist
 

--- a/internal/pkg/narrowcache/client.go
+++ b/internal/pkg/narrowcache/client.go
@@ -81,28 +81,32 @@ func (c *Client) getAndCreateWatchIfNeeded(ctx context.Context, info GVKInfo, gv
 	// Live query
 	rlog := log.FromContext(ctx).WithName("narrowcache").WithValues("objKey", objKey)
 	rlog.Info("Cache miss, doing live query")
-	fetched, err := info.Getter(ctx, c.liveClient, key)
-	if err != nil {
-		return nil, objKey, err
-	}
-
-	// Create watch for later calls
-	w, err := info.Watcher(ctx, c.liveClient, key)
-	if err != nil {
-		return nil, objKey, err
-	}
-
-	// Store fetched object
-	obj := info.Cleanup(fetched)
-	err = c.setToCache(objKey, obj)
+	fetched, w, err := c.fetchAndWatch(ctx, objKey, info, key)
 	if err != nil {
 		return nil, objKey, err
 	}
 
 	// Start updating goroutine
-	go c.updateCache(ctx, objKey, w)
+	go c.updateCache(ctx, objKey, info, key, w)
 
-	return fetched.(client.Object), objKey, nil
+	return fetched, objKey, nil
+}
+
+func (c *Client) fetchAndWatch(ctx context.Context, cacheKey string, info GVKInfo, objKey client.ObjectKey) (client.Object, watch.Interface, error) {
+	fetched, err := info.Getter(ctx, c.liveClient, objKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	w, err := info.Watcher(ctx, c.liveClient, objKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	info.Cleanup(fetched)
+	if err := c.setToCache(cacheKey, fetched); err != nil {
+		w.Stop()
+		return nil, nil, err
+	}
+	return fetched.(client.Object), w, nil
 }
 
 // "Terrible hack" cc directxman12 / sigs.k8s.io/controller-runtime/pkg/cache/internal/cache_reader.go
@@ -121,12 +125,12 @@ func copyInto(obj runtime.Object, out client.Object) error {
 	return nil
 }
 
-func (c *Client) updateCache(ctx context.Context, key string, watcher watch.Interface) {
+func (c *Client) updateCache(ctx context.Context, cacheKey string, info GVKInfo, objKey client.ObjectKey, watcher watch.Interface) {
 	rlog := log.FromContext(ctx).WithName("narrowcache")
 	defer func() {
 		watcher.Stop()
-		rlog.WithValues("key", key).Info("Watch terminated. Clearing cache entry.")
-		c.clearEntryByKey(key)
+		rlog.WithValues("key", cacheKey).Info("Watch terminated. Clearing cache entry.")
+		c.clearEntryByKey(cacheKey)
 	}()
 
 	for {
@@ -135,17 +139,32 @@ func (c *Client) updateCache(ctx context.Context, key string, watcher watch.Inte
 			return
 		case watchEvent, ok := <-watcher.ResultChan():
 			if !ok {
-				return
+				// Watch channel closed (normal API timeout). Re-establish the watch
+				// to avoid losing handlers and missing subsequent events.
+				rlog.WithValues("key", cacheKey).Info("Watch channel closed, re-establishing")
+				watcher.Stop()
+
+				obj, newWatcher, err := c.fetchAndWatch(ctx, cacheKey, info, objKey)
+				if err != nil {
+					rlog.WithValues("key", cacheKey).Error(err, "Failed to re-establish watch")
+					return
+				}
+
+				// Notify handlers so controllers re-check current state
+				c.callHandlers(ctx, cacheKey, watch.Event{Type: watch.Modified, Object: obj})
+
+				watcher = newWatcher
+				continue
 			}
-			rlog.WithValues("key", key, "event type", watchEvent.Type).Info("Event received")
+			rlog.WithValues("key", cacheKey, "event type", watchEvent.Type).Info("Event received")
 			if watchEvent.Type == watch.Added || watchEvent.Type == watch.Modified {
-				if err := c.setToCache(key, watchEvent.Object); err != nil {
-					rlog.WithValues("key", key).Error(err, "Error while updating cache")
+				if err := c.setToCache(cacheKey, watchEvent.Object); err != nil {
+					rlog.WithValues("key", cacheKey).Error(err, "Error while updating cache")
 				}
 			} else if watchEvent.Type == watch.Deleted {
-				c.removeFromCache(key)
+				c.removeFromCache(cacheKey)
 			}
-			c.callHandlers(ctx, key, watchEvent)
+			c.callHandlers(ctx, cacheKey, watchEvent)
 		}
 	}
 }

--- a/internal/pkg/narrowcache/client_test.go
+++ b/internal/pkg/narrowcache/client_test.go
@@ -1,0 +1,111 @@
+package narrowcache
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type gvkClient struct {
+	client.Client
+}
+
+func (c *gvkClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return apiutil.GVKForObject(obj, scheme.Scheme)
+}
+
+func TestWatchReestablishment(t *testing.T) {
+	assert := assert.New(t)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "test-ns"},
+		Data:       map[string]string{"key": "value1"},
+	}
+	goclient := fake.NewClientset(cm)
+
+	// Intercept watch calls to control when the watch channel closes
+	watcher1 := watch.NewFake()
+	watcher2 := watch.NewFake()
+	var watchCount atomic.Int32
+	goclient.PrependWatchReactor("configmaps", func(_ k8stesting.Action) (bool, watch.Interface, error) {
+		if watchCount.Add(1) == 1 {
+			return true, watcher1, nil
+		}
+		return true, watcher2, nil
+	})
+
+	NewLiveClient = func(_ *rest.Config) (kubernetes.Interface, error) {
+		return goclient, nil
+	}
+	narrowCache := NewConfig(&rest.Config{}, ConfigMaps)
+	underlying := &gvkClient{}
+	nc, err := narrowCache.CreateClient(underlying)
+	assert.NoError(err)
+
+	ctx := context.Background()
+
+	// First Get: triggers live query + starts watch goroutine
+	out := &corev1.ConfigMap{}
+	err = nc.Get(ctx, client.ObjectKey{Name: "test-cm", Namespace: "test-ns"}, out)
+	assert.NoError(err)
+	assert.Equal("value1", out.Data["key"])
+	assert.Equal(int32(1), watchCount.Load())
+
+	// Register a handler via GetSource + Start to verify it survives watch re-establishment
+	var handlerCalls atomic.Int32
+	src, err := nc.GetSource(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "test-ns"},
+	}, handler.Funcs{
+		UpdateFunc: func(_ context.Context, _ event.UpdateEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			handlerCalls.Add(1)
+		},
+	})
+	assert.NoError(err)
+	q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer q.ShutDown()
+	assert.NoError(src.Start(ctx, q))
+
+	// Simulate API watch timeout: closing the channel triggers re-establishment
+	watcher1.Stop()
+
+	// Watch should be re-established, and handler notified
+	assert.Eventually(func() bool { return watchCount.Load() == 2 }, 2*time.Second, 50*time.Millisecond,
+		"expected watch to be re-established")
+	assert.Eventually(func() bool { return handlerCalls.Load() > 0 }, 2*time.Second, 50*time.Millisecond,
+		"expected handler to be called on re-establishment")
+
+	// Cache still returns valid data after re-establishment
+	out2 := &corev1.ConfigMap{}
+	assert.NoError(nc.Get(ctx, client.ObjectKey{Name: "test-cm", Namespace: "test-ns"}, out2))
+	assert.Equal("value1", out2.Data["key"])
+
+	// Events on the new watch are processed
+	updatedCM := cm.DeepCopy()
+	updatedCM.Data["key"] = "value2"
+	watcher2.Modify(updatedCM)
+
+	assert.Eventually(func() bool {
+		out3 := &corev1.ConfigMap{}
+		_ = nc.Get(ctx, client.ObjectKey{Name: "test-cm", Namespace: "test-ns"}, out3)
+		return out3.Data["key"] == "value2"
+	}, 2*time.Second, 50*time.Millisecond, "expected cache to reflect update via new watch")
+}

--- a/internal/pkg/narrowcache/config.go
+++ b/internal/pkg/narrowcache/config.go
@@ -28,7 +28,7 @@ type GVKInfo struct {
 	Obj     client.Object
 	Getter  func(ctx context.Context, cl kubernetes.Interface, key client.ObjectKey) (runtime.Object, error)
 	Watcher func(ctx context.Context, cl kubernetes.Interface, key client.ObjectKey) (watch.Interface, error)
-	Cleanup func(obj runtime.Object) runtime.Object
+	Cleanup func(obj runtime.Object)
 }
 
 var (
@@ -41,11 +41,10 @@ var (
 			opts := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, key.Name).String()}
 			return cl.CoreV1().ConfigMaps(key.Namespace).Watch(ctx, opts)
 		},
-		Cleanup: func(obj runtime.Object) runtime.Object {
+		Cleanup: func(obj runtime.Object) {
 			cm := obj.(*corev1.ConfigMap)
 			cm.SetManagedFields([]metav1.ManagedFieldsEntry{})
 			cm.BinaryData = nil
-			return cm
 		},
 	}
 	ClusterRoles = GVKInfo{
@@ -57,10 +56,9 @@ var (
 			opts := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, key.Name).String()}
 			return cl.RbacV1().ClusterRoles().Watch(ctx, opts)
 		},
-		Cleanup: func(obj runtime.Object) runtime.Object {
+		Cleanup: func(obj runtime.Object) {
 			cr := obj.(*rbacv1.ClusterRole)
 			cr.SetManagedFields([]metav1.ManagedFieldsEntry{})
-			return cr
 		},
 	}
 	ClusterRoleBindings = GVKInfo{
@@ -72,10 +70,9 @@ var (
 			opts := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, key.Name).String()}
 			return cl.RbacV1().ClusterRoleBindings().Watch(ctx, opts)
 		},
-		Cleanup: func(obj runtime.Object) runtime.Object {
+		Cleanup: func(obj runtime.Object) {
 			crb := obj.(*rbacv1.ClusterRoleBinding)
 			crb.SetManagedFields([]metav1.ManagedFieldsEntry{})
-			return crb
 		},
 	}
 	Daemonsets = GVKInfo{
@@ -87,11 +84,10 @@ var (
 			opts := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, key.Name).String()}
 			return cl.AppsV1().DaemonSets(key.Namespace).Watch(ctx, opts)
 		},
-		Cleanup: func(obj runtime.Object) runtime.Object {
+		Cleanup: func(obj runtime.Object) {
 			ds := obj.(*appsv1.DaemonSet)
 			ds.SetManagedFields([]metav1.ManagedFieldsEntry{})
 			ds.Status.Conditions = []appsv1.DaemonSetCondition{}
-			return ds
 		},
 	}
 	Deployments = GVKInfo{
@@ -103,11 +99,10 @@ var (
 			opts := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, key.Name).String()}
 			return cl.AppsV1().Deployments(key.Namespace).Watch(ctx, opts)
 		},
-		Cleanup: func(obj runtime.Object) runtime.Object {
+		Cleanup: func(obj runtime.Object) {
 			dpl := obj.(*appsv1.Deployment)
 			dpl.SetManagedFields([]metav1.ManagedFieldsEntry{})
 			dpl.Status.Conditions = []appsv1.DeploymentCondition{}
-			return dpl
 		},
 	}
 	HorizontalPodAutoscalers = GVKInfo{
@@ -119,12 +114,11 @@ var (
 			opts := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, key.Name).String()}
 			return cl.AutoscalingV2().HorizontalPodAutoscalers(key.Namespace).Watch(ctx, opts)
 		},
-		Cleanup: func(obj runtime.Object) runtime.Object {
+		Cleanup: func(obj runtime.Object) {
 			hpa := obj.(*ascv2.HorizontalPodAutoscaler)
 			hpa.SetManagedFields([]metav1.ManagedFieldsEntry{})
 			hpa.Status.CurrentMetrics = []ascv2.MetricStatus{}
 			hpa.Status.Conditions = []ascv2.HorizontalPodAutoscalerCondition{}
-			return hpa
 		},
 	}
 	Namespaces = GVKInfo{
@@ -136,11 +130,10 @@ var (
 			opts := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, key.Name).String()}
 			return cl.CoreV1().Namespaces().Watch(ctx, opts)
 		},
-		Cleanup: func(obj runtime.Object) runtime.Object {
+		Cleanup: func(obj runtime.Object) {
 			ns := obj.(*corev1.Namespace)
 			ns.SetManagedFields([]metav1.ManagedFieldsEntry{})
 			ns.Status.Conditions = []corev1.NamespaceCondition{}
-			return ns
 		},
 	}
 	NetworkPolicies = GVKInfo{
@@ -152,10 +145,9 @@ var (
 			opts := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, key.Name).String()}
 			return cl.NetworkingV1().NetworkPolicies(key.Namespace).Watch(ctx, opts)
 		},
-		Cleanup: func(obj runtime.Object) runtime.Object {
+		Cleanup: func(obj runtime.Object) {
 			np := obj.(*networkingv1.NetworkPolicy)
 			np.SetManagedFields([]metav1.ManagedFieldsEntry{})
-			return np
 		},
 	}
 	Roles = GVKInfo{
@@ -167,10 +159,9 @@ var (
 			opts := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, key.Name).String()}
 			return cl.RbacV1().Roles(key.Namespace).Watch(ctx, opts)
 		},
-		Cleanup: func(obj runtime.Object) runtime.Object {
+		Cleanup: func(obj runtime.Object) {
 			ro := obj.(*rbacv1.Role)
 			ro.SetManagedFields([]metav1.ManagedFieldsEntry{})
-			return ro
 		},
 	}
 	RoleBindings = GVKInfo{
@@ -182,10 +173,9 @@ var (
 			opts := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, key.Name).String()}
 			return cl.RbacV1().RoleBindings(key.Namespace).Watch(ctx, opts)
 		},
-		Cleanup: func(obj runtime.Object) runtime.Object {
+		Cleanup: func(obj runtime.Object) {
 			rb := obj.(*rbacv1.RoleBinding)
 			rb.SetManagedFields([]metav1.ManagedFieldsEntry{})
-			return rb
 		},
 	}
 	Secrets = GVKInfo{
@@ -197,11 +187,10 @@ var (
 			opts := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, key.Name).String()}
 			return cl.CoreV1().Secrets(key.Namespace).Watch(ctx, opts)
 		},
-		Cleanup: func(obj runtime.Object) runtime.Object {
+		Cleanup: func(obj runtime.Object) {
 			sc := obj.(*corev1.Secret)
 			sc.SetManagedFields([]metav1.ManagedFieldsEntry{})
 			sc.StringData = nil
-			return sc
 		},
 	}
 	Services = GVKInfo{
@@ -213,12 +202,11 @@ var (
 			opts := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, key.Name).String()}
 			return cl.CoreV1().Services(key.Namespace).Watch(ctx, opts)
 		},
-		Cleanup: func(obj runtime.Object) runtime.Object {
+		Cleanup: func(obj runtime.Object) {
 			sv := obj.(*corev1.Service)
 			sv.SetManagedFields([]metav1.ManagedFieldsEntry{})
 			sv.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{}
 			sv.Status.Conditions = []metav1.Condition{}
-			return sv
 		},
 	}
 	ServiceAccounts = GVKInfo{
@@ -230,10 +218,9 @@ var (
 			opts := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, key.Name).String()}
 			return cl.CoreV1().ServiceAccounts(key.Namespace).Watch(ctx, opts)
 		},
-		Cleanup: func(obj runtime.Object) runtime.Object {
+		Cleanup: func(obj runtime.Object) {
 			sa := obj.(*corev1.ServiceAccount)
 			sa.SetManagedFields([]metav1.ManagedFieldsEntry{})
-			return sa
 		},
 	}
 	Endpoints = GVKInfo{
@@ -246,13 +233,12 @@ var (
 			opts := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, key.Name).String()}
 			return cl.CoreV1().Endpoints(key.Namespace).Watch(ctx, opts)
 		},
-		Cleanup: func(obj runtime.Object) runtime.Object {
+		Cleanup: func(obj runtime.Object) {
 			//nolint:staticcheck // SA1019: Endpoints is deprecated but used as fallback for k8s < 1.21
 			e := obj.(*corev1.Endpoints)
 			e.SetManagedFields([]metav1.ManagedFieldsEntry{})
 			//nolint:staticcheck // SA1019: Endpoints is deprecated but used as fallback for k8s < 1.21
 			e.Subsets = []corev1.EndpointSubset{}
-			return e
 		},
 	}
 	EndpointSlices = GVKInfo{
@@ -264,12 +250,11 @@ var (
 			opts := metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector(metav1.ObjectNameField, key.Name).String()}
 			return cl.DiscoveryV1().EndpointSlices(key.Namespace).Watch(ctx, opts)
 		},
-		Cleanup: func(obj runtime.Object) runtime.Object {
+		Cleanup: func(obj runtime.Object) {
 			e := obj.(*discoveryv1.EndpointSlice)
 			e.SetManagedFields([]metav1.ManagedFieldsEntry{})
 			e.Endpoints = []discoveryv1.Endpoint{}
 			e.Ports = []discoveryv1.EndpointPort{}
-			return e
 		},
 	}
 	NewLiveClient func(c *rest.Config) (kubernetes.Interface, error) = func(c *rest.Config) (kubernetes.Interface, error) {


### PR DESCRIPTION
## Description

When a Kubernetes API watch expires (normal ~5-10min timeout), the narrowcache was clearing the cache entry entirely, losing registered handlers. This meant controllers watching secrets/configmaps via GetSource would never be notified of changes after the first watch expired.

Now, on watch channel close, fetchAndWatch re-fetches the object and creates a new watch, preserving handlers and notifying them of the current state. Also simplifies GVKInfo.Cleanup signature to void since all implementations mutate in place.

Co-Authored-By: Claude Opus 4.6

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [x] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache reliability by automatically re-establishing watches when connections close.
  * Preserved cached data and event handlers during watch recovery.
  * Cleared stale cache data when watch re-establishment fails.
  * Notified registered handlers after successfully restoring a watch.
* **Tests**
  * Added coverage verifying watch recovery and propagation of updates from replacement watches.
* **Documentation**
  * Clarified controller and cache guidance, including watch requirements and generated-file editing rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->