### PR TITLE
NETOBSERV-2912: Enable PQC in OpenSSL: switch to ubi-minimal-pqc base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY config/crd/bases config/crd/bases
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags "$LDFLAGS" -mod vendor -a -o manager main.go
 
 # Create final image from minimal + built binary
-FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi-minimal:9.8-1781496742
+FROM --platform=linux/$TARGETARCH registry.redhat.io/ubi9/ubi-minimal-pqc:9.8
 WORKDIR /
 COPY --from=builder /opt/app-root/manager .
 USER 65532:65532

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 ARG TARGETARCH
 
+# PQC crypto-policies builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8 AS crypto-builder
+RUN microdnf install -y crypto-policies-scripts && \
+    update-crypto-policies --set DEFAULT:PQ && \
+    microdnf clean all && rm -rf /var/cache/*
+
 # Build the manager binary
 FROM docker.io/library/golang:1.26 AS builder
 
@@ -21,8 +27,9 @@ COPY config/crd/bases config/crd/bases
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags "$LDFLAGS" -mod vendor -a -o manager main.go
 
 # Create final image from minimal + built binary
-FROM --platform=linux/$TARGETARCH registry.redhat.io/ubi9/ubi-minimal-pqc:9.8
+FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi-minimal:9.8-1781496742
 WORKDIR /
+COPY --from=crypto-builder /etc/crypto-policies/ /etc/crypto-policies/
 COPY --from=builder /opt/app-root/manager .
 USER 65532:65532
 

--- a/integration-tests/backend/Dockerfile
+++ b/integration-tests/backend/Dockerfile
@@ -17,7 +17,7 @@ COPY testdata/ testdata/
 RUN GOGC=50 GOMAXPROCS=4 GOOS=linux GOARCH=$TARGETARCH \
     ginkgo build --ldflags="-s -w" -o e2e-tests.test
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1777460003
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:9.8
 
 RUN microdnf install -y which findutils util-linux procps-ng net-tools iputils bind-utils wget tar gzip httpd-tools && \
     microdnf clean all

--- a/integration-tests/backend/Dockerfile
+++ b/integration-tests/backend/Dockerfile
@@ -1,3 +1,9 @@
+# PQC crypto-policies builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8 AS crypto-builder
+RUN microdnf install -y crypto-policies-scripts && \
+    update-crypto-policies --set DEFAULT:PQ && \
+    microdnf clean all && rm -rf /var/cache/*
+
 FROM docker.io/library/golang:1.26 AS builder
 
 ARG TARGETARCH=amd64
@@ -17,7 +23,7 @@ COPY testdata/ testdata/
 RUN GOGC=50 GOMAXPROCS=4 GOOS=linux GOARCH=$TARGETARCH \
     ginkgo build --ldflags="-s -w" -o e2e-tests.test
 
-FROM registry.redhat.io/ubi9/ubi-minimal-pqc:9.8
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1777460003
 
 RUN microdnf install -y which findutils util-linux procps-ng net-tools iputils bind-utils wget tar gzip httpd-tools && \
     microdnf clean all
@@ -25,6 +31,7 @@ RUN microdnf install -y which findutils util-linux procps-ng net-tools iputils b
 WORKDIR /tests
 
 # Copy the pre-compiled test binary, testdata and ginkgo binary
+COPY --from=crypto-builder /etc/crypto-policies/ /etc/crypto-policies/
 COPY --from=builder /workspace/e2e-tests.test .
 COPY --from=builder /workspace/testdata/ testdata/
 COPY --from=builder /go/bin/ginkgo /usr/local/bin/ginkgo


### PR DESCRIPTION
## Description

Enable `DEFAULT:PQ` crypto policy for post-quantum cryptography support using a multi-stage build. A `crypto-builder` stage installs `crypto-policies-scripts`, configures `DEFAULT:PQ`, and the resulting `/etc/crypto-policies/` is copied into the runtime image. This makes ML-KEM available via OpenSSL without changing the base image.

This is part of the OCP 5.0 PQC initiative ([OCPSTRAT-3113](https://issues.redhat.com/browse/OCPSTRAT-3113)). The crypto policy switch is transparent to the operator — it does not alter behavior or APIs.

**Approach:** Based on [openshift/images#230](https://github.com/openshift/images/pull/230).

**Verification:**
```bash
podman build -t netobserv-operator-pqc-test -f Dockerfile .
podman run --rm --entrypoint cat netobserv-operator-pqc-test /etc/crypto-policies/state/current
# Output: DEFAULT:PQ
```

**Images updated:**
- `Dockerfile` (operator image)
- `integration-tests/backend/Dockerfile` (e2e test image)

**Not affected:**
- `bundle.Dockerfile` (uses `scratch`)
- `catalog.Dockerfile` (uses `opm` base)

## Dependencies

n/a

## Checklist

* [x] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

## Testing

```
$ podman build -t netobserv-operator-pqc-test -f Dockerfile .
$ podman run --rm --entrypoint cat netobserv-operator-pqc-test /etc/crypto-policies/state/current
DEFAULT:PQ
```

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve [NETOBSERV-2912](https://redhat.atlassian.net/browse/NETOBSERV-2912)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Enabled post-quantum cryptography policies in the application and backend runtime environments.
  * Added the required cryptographic policy configuration to container images for consistent security settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->