### PR TITLE
fix: add resource requests to static plugin reconciler

### DIFF
--- a/bundles/k8s/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundles/k8s/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -1013,6 +1013,12 @@ spec:
                   value: quay.io/netobserv/network-observability-console-plugin:v1.12.0-community-pf5
                 - name: RELATED_IMAGE_DEMO_LOKI
                   value: grafana/loki:3.5.0
+                - name: STATIC_PLUGIN_CPU_REQUEST
+                  value: 10m
+                - name: STATIC_PLUGIN_MEMORY_REQUEST
+                  value: 64Mi
+                - name: STATIC_PLUGIN_CPU_LIMIT
+                - name: STATIC_PLUGIN_MEMORY_LIMIT
                 - name: NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/bundles/openshift/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundles/openshift/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -1011,6 +1011,12 @@ spec:
                   value: quay.io/netobserv/network-observability-console-plugin:v1.12.0-community-pf5
                 - name: RELATED_IMAGE_DEMO_LOKI
                   value: grafana/loki:3.5.0
+                - name: STATIC_PLUGIN_CPU_REQUEST
+                  value: 10m
+                - name: STATIC_PLUGIN_MEMORY_REQUEST
+                  value: 64Mi
+                - name: STATIC_PLUGIN_CPU_LIMIT
+                - name: STATIC_PLUGIN_MEMORY_LIMIT
                 - name: NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -37,6 +37,14 @@ spec:
             value: quay.io/netobserv/network-observability-console-plugin:v1.12.0-community-pf5
           - name: RELATED_IMAGE_DEMO_LOKI
             value: grafana/loki:3.5.0
+          - name: STATIC_PLUGIN_CPU_REQUEST
+            value: "10m"
+          - name: STATIC_PLUGIN_MEMORY_REQUEST
+            value: "64Mi"
+          - name: STATIC_PLUGIN_CPU_LIMIT
+            value: ""
+          - name: STATIC_PLUGIN_MEMORY_LIMIT
+            value: ""
           - name: NAMESPACE
             valueFrom:
               fieldRef:

--- a/internal/controller/consoleplugin/consoleplugin_static_reconciler.go
+++ b/internal/controller/consoleplugin/consoleplugin_static_reconciler.go
@@ -2,6 +2,7 @@ package consoleplugin
 
 import (
 	"context"
+	"fmt"
 
 	osv1 "github.com/openshift/api/console/v1"
 	olm "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -59,6 +60,10 @@ func (r *StaticReconciler) ReconcileStaticPlugin(ctx context.Context, enable boo
 		}
 	}
 
+	resources, err := buildStaticPluginResources(&r.managerConfig.StaticPluginConfig)
+	if err != nil {
+		return fmt.Errorf("building static plugin resources: %w", err)
+	}
 	// Fake a FlowCollector to create console plugin and expose forms
 	return r.reconcileStatic(ctx, &flowslatest.FlowCollector{
 		Spec: flowslatest.FlowCollectorSpec{
@@ -68,7 +73,7 @@ func (r *StaticReconciler) ReconcileStaticPlugin(ctx context.Context, enable boo
 			ConsolePlugin: flowslatest.FlowCollectorConsolePlugin{
 				Enable:    ptr.To(enable),
 				LogLevel:  "info",
-				Resources: buildStaticPluginResources(r.cfg),
+				Resources: resources,
 				Advanced: &flowslatest.AdvancedPluginConfig{
 					Register:   ptr.To(true),
 					Scheduling: sched,
@@ -78,7 +83,7 @@ func (r *StaticReconciler) ReconcileStaticPlugin(ctx context.Context, enable boo
 	})
 }
 
-func buildStaticPluginResources(cfg *manager.StaticPluginConfig) corev1.ResourceRequirements {
+func buildStaticPluginResources(cfg *manager.StaticPluginConfig) (corev1.ResourceRequirements, error) {
 	cpuRequest := cfg.CPURequest
 	if cpuRequest == "" {
 		cpuRequest = "10m"
@@ -87,21 +92,38 @@ func buildStaticPluginResources(cfg *manager.StaticPluginConfig) corev1.Resource
 	if memoryRequest == "" {
 		memoryRequest = "64Mi"
 	}
+
+	cpuQty, err := resource.ParseQuantity(cpuRequest)
+	if err != nil {
+		return corev1.ResourceRequirements{}, fmt.Errorf("invalid CPU request %q: %w", cpuRequest, err)
+	}
+	memoryQty, err := resource.ParseQuantity(memoryRequest)
+	if err != nil {
+		return corev1.ResourceRequirements{}, fmt.Errorf("invalid memory request %q: %w", memoryRequest, err)
+	}
 	requests := corev1.ResourceList{
-		corev1.ResourceCPU:    resource.MustParse(cpuRequest),
-		corev1.ResourceMemory: resource.MustParse(memoryRequest),
+		corev1.ResourceCPU:    cpuQty,
+		corev1.ResourceMemory: memoryQty,
 	}
 	limits := corev1.ResourceList{}
 	if cfg.CPULimit != "" {
-		limits[corev1.ResourceCPU] = resource.MustParse(cfg.CPULimit)
+		cpuLimit, err := resource.ParseQuantity(cfg.CPULimit)
+		if err != nil {
+			return corev1.ResourceRequirements{}, fmt.Errorf("invalid CPU limit %q: %w", cfg.CPULimit, err)
+		}
+		limits[corev1.ResourceCPU] = cpuLimit
 	}
 	if cfg.MemoryLimit != "" {
-		limits[corev1.ResourceMemory] = resource.MustParse(cfg.MemoryLimit)
+		memoryLimit, err := resource.ParseQuantity(cfg.MemoryLimit)
+		if err != nil {
+			return corev1.ResourceRequirements{}, fmt.Errorf("invalid memory limit %q: %w", cfg.MemoryLimit, err)
+		}
+		limits[corev1.ResourceMemory] = memoryLimit
 	}
 	return corev1.ResourceRequirements{
 		Requests: requests,
 		Limits:   limits,
-	}
+	}, nil
 }
 
 // Reconcile is the reconciler entry point to reconcile the static plugin state with the desired configuration

--- a/internal/controller/consoleplugin/consoleplugin_static_reconciler.go
+++ b/internal/controller/consoleplugin/consoleplugin_static_reconciler.go
@@ -5,9 +5,11 @@ import (
 
 	osv1 "github.com/openshift/api/console/v1"
 	olm "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -66,6 +68,12 @@ func (r *StaticReconciler) ReconcileStaticPlugin(ctx context.Context, enable boo
 			ConsolePlugin: flowslatest.FlowCollectorConsolePlugin{
 				Enable:   ptr.To(enable),
 				LogLevel: "info",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("10m"),
+						corev1.ResourceMemory: resource.MustParse("64Mi"),
+					},
+				},
 				Advanced: &flowslatest.AdvancedPluginConfig{
 					Register:   ptr.To(true),
 					Scheduling: sched,

--- a/internal/controller/consoleplugin/consoleplugin_static_reconciler.go
+++ b/internal/controller/consoleplugin/consoleplugin_static_reconciler.go
@@ -66,14 +66,9 @@ func (r *StaticReconciler) ReconcileStaticPlugin(ctx context.Context, enable boo
 				Enable: r.managerConfig.DeployOperatorNetworkPolicy,
 			},
 			ConsolePlugin: flowslatest.FlowCollectorConsolePlugin{
-				Enable:   ptr.To(enable),
-				LogLevel: "info",
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("10m"),
-						corev1.ResourceMemory: resource.MustParse("64Mi"),
-					},
-				},
+				Enable:    ptr.To(enable),
+				LogLevel:  "info",
+				Resources: buildStaticPluginResources(r.cfg),
 				Advanced: &flowslatest.AdvancedPluginConfig{
 					Register:   ptr.To(true),
 					Scheduling: sched,
@@ -81,6 +76,32 @@ func (r *StaticReconciler) ReconcileStaticPlugin(ctx context.Context, enable boo
 			},
 		},
 	})
+}
+
+func buildStaticPluginResources(cfg *manager.StaticPluginConfig) corev1.ResourceRequirements {
+	cpuRequest := cfg.CPURequest
+	if cpuRequest == "" {
+		cpuRequest = "10m"
+	}
+	memoryRequest := cfg.MemoryRequest
+	if memoryRequest == "" {
+		memoryRequest = "64Mi"
+	}
+	requests := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse(cpuRequest),
+		corev1.ResourceMemory: resource.MustParse(memoryRequest),
+	}
+	limits := corev1.ResourceList{}
+	if cfg.CPULimit != "" {
+		limits[corev1.ResourceCPU] = resource.MustParse(cfg.CPULimit)
+	}
+	if cfg.MemoryLimit != "" {
+		limits[corev1.ResourceMemory] = resource.MustParse(cfg.MemoryLimit)
+	}
+	return corev1.ResourceRequirements{
+		Requests: requests,
+		Limits:   limits,
+	}
 }
 
 // Reconcile is the reconciler entry point to reconcile the static plugin state with the desired configuration

--- a/internal/pkg/manager/config.go
+++ b/internal/pkg/manager/config.go
@@ -36,6 +36,14 @@ type Config struct {
 type StaticPluginConfig struct {
 	// Inherit toleration from Subscriptions, for static controller (static plugin); this must refer to the subscription name
 	InheritTolerationFromSubscription string
+	// CPU request for the static plugin Deployment
+	CPURequest string
+	// Memory request for the static plugin Deployment
+	MemoryRequest string
+	// CPU limit for the static plugin Deployment (empty = no limit)
+	CPULimit string
+	// Memory limit for the static plugin Deployment (empty = no limit)
+	MemoryLimit string
 }
 
 // ResolveWebConsoleImage selects the web console image appropriate for the cluster version.

--- a/main.go
+++ b/main.go
@@ -310,6 +310,10 @@ func readConfigFromEnv() (*manager.Config, error) {
 		Namespace:             defaultStringEnv("NAMESPACE", "netobserv"),
 		StaticPluginConfig: manager.StaticPluginConfig{
 			InheritTolerationFromSubscription: os.Getenv("STATIC_PLUGIN_INHERIT_TOLERATION_SUBSCRIPTION"),
+			CPURequest:                        defaultStringEnv("STATIC_PLUGIN_CPU_REQUEST", "10m"),
+			MemoryRequest:                     defaultStringEnv("STATIC_PLUGIN_MEMORY_REQUEST", "64Mi"),
+			CPULimit:                          defaultStringEnv("STATIC_PLUGIN_CPU_LIMIT", ""),
+			MemoryLimit:                       defaultStringEnv("STATIC_PLUGIN_MEMORY_LIMIT", ""),
 		},
 		DeployOperatorNetworkPolicy: deployNetpol,
 	}, nil


### PR DESCRIPTION

The `netobserv-plugin-static` Deployment deployed by the operator has empty `resources: {}` on its container spec. 

This results in:
- **VPA cannot function** (requires an existing resource spec) — this is the primary blocker
- QoS class defaults to BestEffort
- Unpredictable scheduling

Add explicit resource **requests only** (CPU: 10m, memory: 64Mi) to the fake `FlowCollector` object in `consoleplugin_static_reconciler.go`. This ensures the static plugin Deployment has resource requests by default, allowing VPAs to work and pods to get a proper QoS class.

**No limits are included** to avoid breaking existing deployments that rely on the operator-managed replica count and any external autoscaling (HPA/KEDA).

<img width="1229" height="743" alt="image" src="https://github.com/user-attachments/assets/cf2a25c7-50e2-4533-ba21-8287ff34d51d" />


## Related Issues

Fixes #2891

## Long-term

This PR is a minimal fix. A long-term plan should expose resource requests/limits and replica count as tunables in the `FlowCollector` CR, allowing users to configure these values alongside the existing console plugin configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable CPU and memory requests and limits for the static console plugin.
  - Static plugin deployments now default to 10m CPU and 64Mi memory requests.
  - Deployment configuration exposes environment variables for adjusting static plugin resource settings.
  - Empty limit values indicate that no resource limit is applied.

- **Bug Fixes**
  - Invalid CPU or memory resource values now produce clear configuration errors instead of causing unexpected failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->