### PR TITLE
fix: Add AdminNetworkPolicy resource mappings for test cleanup

### DIFF
--- a/integration-tests/backend/k8s_client.go
+++ b/integration-tests/backend/k8s_client.go
@@ -103,6 +103,10 @@ var gvrMap = map[string]schema.GroupVersionResource{
 	// OpenShift cluster operator
 	"clusteroperator": {Group: "config.openshift.io", Version: "v1", Resource: "clusteroperators"},
 
+	// Network Policy (AdminNetworkPolicy)
+	"adminnetworkpolicy":         {Group: "policy.networking.k8s.io", Version: "v1alpha1", Resource: "adminnetworkpolicies"},
+	"baselineadminnetworkpolicy": {Group: "policy.networking.k8s.io", Version: "v1alpha1", Resource: "baselineadminnetworkpolicies"},
+
 	// User-defined networks (OVN)
 	"userdefinednetwork":        {Group: "k8s.ovn.org", Version: "v1", Resource: "userdefinednetworks"},
 	"clusteruserdefinednetwork": {Group: "k8s.ovn.org", Version: "v1", Resource: "clusteruserdefinednetworks"},

--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -1632,7 +1632,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		banpParameters := []string{"--ignore-unknown-parameters=true", "-p", "SERVER_NS=" + testClient1Template.ServerNS, "CLIENT1_NS=" + testClient1Template.ClientNS, "CLIENT2_NS=" + testClient2Template.ClientNS, "-f", banpTemplate}
 
 		// banp is a cluster scoped resource so passing empty string for NS arg.
-		defer deleteResource("banp", "default", "")
+		defer deleteResource("baselineadminnetworkpolicy", "default", "")
 		err = applyResourceFromTemplateByAdmin(banpParameters...)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -1673,7 +1673,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		anpTemplate := filePath.Join(baseDir, "networking", "adminnetworkPolicy.yaml")
 		anpName := "server-ns"
 		anpParameters := []string{"--ignore-unknown-parameters=true", "-p", "NAM=" + anpName, "SERVER_NS=" + testClient1Template.ServerNS, "ALLOW_NS=" + testClient2Template.ClientNS, "DENY_NS=" + testClient1Template.ClientNS, "-f", anpTemplate}
-		defer deleteResource("anp", anpName, "")
+		defer deleteResource("adminnetworkpolicy", anpName, "")
 		err = applyResourceFromTemplateByAdmin(anpParameters...)
 		o.Expect(err).NotTo(o.HaveOccurred())
 


### PR DESCRIPTION
## Description

Fixes the Network Policy Correlation test (test 77894) cleanup failure.

The test was failing during cleanup phase with error:
```
unknown resource type "anp" — add it to gvrMap in k8s_client.go
```

**Root Cause:** The test cleanup code was calling `deleteResource("anp", ...)` and `deleteResource("banp", ...)` but these resource type abbreviations were not present in the `gvrMap` in `k8s_client.go`.

**Fix:**
- Added `adminnetworkpolicy` and `baselineadminnetworkpolicy` GVR mappings to `k8s_client.go`
- Updated the defer cleanup statements to use full resource names (following the existing pattern for non-common resources)

**Note:** The network policy correlation feature itself was working correctly - flows were being captured with proper metadata. Only the test cleanup phase was failing.

## Dependencies

n/a

## Checklist

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ] No special setup needed - standard periodic test environment
* [ ] I have added thorough unit tests for the change.
   * This is a test infrastructure fix, not a product change
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

**Validation:** This fix will be validated by test 77894 (Network Policy Correlation) passing in periodic runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration test coverage for OpenShift admin and baseline admin network policies.
  * Updated network policy cleanup handling to use the correct resource names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->