### PR TITLE
NETOBSERV-2949 Fix/gcs bucket cleanup leak

### DIFF
--- a/integration-tests/backend/azure_utils.go
+++ b/integration-tests/backend/azure_utils.go
@@ -424,7 +424,7 @@ func createAzureStorageBlobContainer(accountName, accountKey, containerName stri
 	return emptyAzureBlobContainer(container)
 }
 
-// deleteAzureStorageBlobContainer deletes azure storage container
+// deleteAzureStorageBlobContainer deletes azure storage container with retry logic for transient errors
 func deleteAzureStorageBlobContainer(accountName, accountKey, containerName string) error {
 	container, err := newAzureContainerClient(accountName, accountKey, containerName)
 	if err != nil {
@@ -433,22 +433,37 @@ func deleteAzureStorageBlobContainer(accountName, accountKey, containerName stri
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	err = emptyAzureBlobContainer(container)
-	if err != nil {
-		return err
+
+	var lastErr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		// Remove all blobs first
+		err = emptyAzureBlobContainer(container)
+		if err != nil {
+			lastErr = err
+			e2e.Logf("attempt %d/3: failed to empty container %s: %v", attempt, containerName, err)
+			time.Sleep(time.Duration(attempt) * 5 * time.Second)
+			continue
+		}
+
+		// Delete the container
+		_, err = container.Delete(ctx, azblob.ContainerAccessConditions{})
+		if err != nil {
+			lastErr = err
+			e2e.Logf("attempt %d/3: failed to delete container %s: %v", attempt, containerName, err)
+			time.Sleep(time.Duration(attempt) * 5 * time.Second)
+			continue
+		}
+		e2e.Logf("Azure storage container %s is deleted", containerName)
+		return nil
 	}
-	_, err = container.Delete(ctx, azblob.ContainerAccessConditions{})
-	if err != nil {
-		return fmt.Errorf("error deleting container: %v", err)
-	}
-	e2e.Logf("Azure storage container is deleted")
-	return nil
+	return fmt.Errorf("failed to delete Azure storage container %s after 3 attempts: %v", containerName, lastErr)
 }
 
 // emptyAzureBlobContainer removes all the files in azure storage container
 func emptyAzureBlobContainer(container azblob.ContainerURL) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	var errs []string
 	for marker := (azblob.Marker{}); marker.NotDone(); { // The parens around Marker{} are required to avoid compiler error.
 		// Get a result segment starting with the blob indicated by the current Marker.
 		listBlob, err := container.ListBlobsFlatSegment(ctx, marker, azblob.ListBlobsSegmentOptions{})
@@ -465,9 +480,13 @@ func emptyAzureBlobContainer(container azblob.ContainerURL) error {
 			blobURL := container.NewBlockBlobURL(blobInfo.Name)
 			_, err := blobURL.Delete(ctx, azblob.DeleteSnapshotsOptionNone, azblob.BlobAccessConditions{})
 			if err != nil {
-				return fmt.Errorf("error deleting blob %s: %v", blobInfo.Name, err)
+				e2e.Logf("WARNING: failed to delete blob %q in container: %v", blobInfo.Name, err)
+				errs = append(errs, fmt.Sprintf("Blob(%q).Delete: %v", blobInfo.Name, err))
 			}
 		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to delete %d blob(s) in container: %s", len(errs), strings.Join(errs, "; "))
 	}
 	e2e.Logf("deleted all blob items in the container.")
 	return nil

--- a/integration-tests/backend/gcp_utils.go
+++ b/integration-tests/backend/gcp_utils.go
@@ -3,6 +3,8 @@ package e2etests
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
@@ -47,6 +49,7 @@ func emptyGCSBucket(client storage.Client, bucketName string) error {
 
 	bucket := client.Bucket(bucketName)
 	it := bucket.Objects(ctx, nil)
+	var errs []string
 	for {
 		objAttrs, err := it.Next()
 		if err != nil && err != iterator.Done {
@@ -56,8 +59,12 @@ func emptyGCSBucket(client storage.Client, bucketName string) error {
 			break
 		}
 		if err := bucket.Object(objAttrs.Name).Delete(ctx); err != nil {
-			return fmt.Errorf("Object(%q).Delete: %v", objAttrs.Name, err)
+			e2e.Logf("WARNING: failed to delete object %q in bucket %s: %v", objAttrs.Name, bucketName, err)
+			errs = append(errs, fmt.Sprintf("Object(%q).Delete: %v", objAttrs.Name, err))
 		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to delete %d object(s) in bucket %s: %s", len(errs), bucketName, strings.Join(errs, "; "))
 	}
 	e2e.Logf("deleted all object items in the bucket %s.", bucketName)
 	return nil
@@ -102,7 +109,7 @@ func createGCSBucket(projectID, bucketName string) error {
 	return nil
 }
 
-// deleteGCSBucket deletes a GCS bucket
+// deleteGCSBucket deletes a GCS bucket with retry logic for transient errors
 func deleteGCSBucket(bucketName string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -113,17 +120,27 @@ func deleteGCSBucket(bucketName string) error {
 	}
 	defer client.Close()
 
-	// Remove all objects first
-	err = emptyGCSBucket(*client, bucketName)
-	if err != nil {
-		return err
-	}
+	var lastErr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		// Remove all objects first
+		err = emptyGCSBucket(*client, bucketName)
+		if err != nil {
+			lastErr = err
+			e2e.Logf("attempt %d/3: failed to empty bucket %s: %v", attempt, bucketName, err)
+			time.Sleep(time.Duration(attempt) * 5 * time.Second)
+			continue
+		}
 
-	// Delete the bucket
-	bucket := client.Bucket(bucketName)
-	if err := bucket.Delete(ctx); err != nil {
-		return fmt.Errorf("Bucket(%q).Delete: %v", bucketName, err)
+		// Delete the bucket
+		bucket := client.Bucket(bucketName)
+		if err := bucket.Delete(ctx); err != nil {
+			lastErr = err
+			e2e.Logf("attempt %d/3: failed to delete bucket %s: %v", attempt, bucketName, err)
+			time.Sleep(time.Duration(attempt) * 5 * time.Second)
+			continue
+		}
+		e2e.Logf("GCS Bucket %v is deleted", bucketName)
+		return nil
 	}
-	e2e.Logf("GCS Bucket %v is deleted", bucketName)
-	return nil
+	return fmt.Errorf("failed to delete GCS bucket %s after 3 attempts: %v", bucketName, lastErr)
 }

--- a/integration-tests/backend/loki_storage.go
+++ b/integration-tests/backend/loki_storage.go
@@ -127,15 +127,31 @@ func createS3Bucket(client *s3.Client, bucketName, region string) error {
 	return err
 }
 
+// deleteS3Bucket deletes an S3 bucket with retry logic for transient errors
 func deleteS3Bucket(client *s3.Client, bucketName string) error {
-	// empty bucket
-	err := emptyS3Bucket(client, bucketName)
-	if err != nil {
-		return err
+	var lastErr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		// Remove all objects first
+		err := emptyS3Bucket(client, bucketName)
+		if err != nil {
+			lastErr = err
+			e2e.Logf("attempt %d/3: failed to empty S3 bucket %s: %v", attempt, bucketName, err)
+			time.Sleep(time.Duration(attempt) * 5 * time.Second)
+			continue
+		}
+
+		// Delete the bucket
+		_, err = client.DeleteBucket(context.TODO(), &s3.DeleteBucketInput{Bucket: &bucketName})
+		if err != nil {
+			lastErr = err
+			e2e.Logf("attempt %d/3: failed to delete S3 bucket %s: %v", attempt, bucketName, err)
+			time.Sleep(time.Duration(attempt) * 5 * time.Second)
+			continue
+		}
+		e2e.Logf("S3 Bucket %s is deleted", bucketName)
+		return nil
 	}
-	// delete bucket
-	_, err = client.DeleteBucket(context.TODO(), &s3.DeleteBucketInput{Bucket: &bucketName})
-	return err
+	return fmt.Errorf("failed to delete S3 bucket %s after 3 attempts: %v", bucketName, lastErr)
 }
 
 func emptyS3Bucket(client *s3.Client, bucketName string) error {

--- a/integration-tests/backend/loki_storage.go
+++ b/integration-tests/backend/loki_storage.go
@@ -975,7 +975,9 @@ func (l lokiStack) removeObjectStorage() {
 			err = deleteS3Bucket(client, l.BucketName)
 		}
 	}
-	o.Expect(err).NotTo(o.HaveOccurred())
+	if err != nil {
+		e2e.Logf("WARNING: failed to clean up object storage for bucket %s: %v", l.BucketName, err)
+	}
 }
 
 func deployMinIO() {

--- a/integration-tests/backend/test_flow_multitenancy.go
+++ b/integration-tests/backend/test_flow_multitenancy.go
@@ -92,6 +92,13 @@ var _ = g.Describe("[sig-netobserv] Network_Observability Multi-Tenancy", g.Orde
 			}
 		}
 
+		// DeferCleanup #1: operator (registered first = cleaned up last)
+		g.DeferCleanup(func() {
+			if !Lokiexisting {
+				LO.uninstallOperator()
+			}
+		})
+
 		g.By("Deploy lokiStack")
 		sc, err := getStorageClassName()
 		if err != nil || len(sc) == 0 {
@@ -105,6 +112,11 @@ var _ = g.Describe("[sig-netobserv] Network_Observability Multi-Tenancy", g.Orde
 
 		err = createNamespace(lokiStackNS)
 		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// DeferCleanup #2: namespace (cleaned up after objectStorage/lokiStack, before operator)
+		g.DeferCleanup(func() {
+			deleteNamespace(lokiStackNS)
+		})
 
 		ls = &lokiStack{
 			Name:          "lokistack",
@@ -128,10 +140,24 @@ var _ = g.Describe("[sig-netobserv] Network_Observability Multi-Tenancy", g.Orde
 			g.Skip("Skipping test since LokiStack resources were not deployed")
 		}
 
+		// DeferCleanup #3: object storage (cleaned up after lokiStack, before namespace)
+		g.DeferCleanup(func() {
+			if ls != nil {
+				ls.removeObjectStorage()
+			}
+		})
+
 		err = ls.deployLokiStack()
 		if err != nil {
 			g.Skip("Skipping test since LokiStack was not deployed")
 		}
+
+		// DeferCleanup #4: lokiStack (registered last = cleaned up first)
+		g.DeferCleanup(func() {
+			if ls != nil {
+				ls.removeLokiStack()
+			}
+		})
 
 		lokiStackResource := Resource{"lokistack", ls.Name, ls.Namespace}
 		err = lokiStackResource.WaitForResourceToAppear()
@@ -148,16 +174,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability Multi-Tenancy", g.Orde
 		g.By("Create secret-watcher RoleBinding in LokiStack namespace")
 		createSecretWatcherRB(lokiStackNS)
 
-		g.DeferCleanup(func() {
-			if ls != nil {
-				ls.removeLokiStack()
-				ls.removeObjectStorage()
-			}
-			if !Lokiexisting {
-				LO.uninstallOperator()
-			}
-			deleteNamespace(lokiStackNS)
-		})
 	})
 
 	g.BeforeEach(func() {

--- a/integration-tests/backend/test_flow_multitenancy.go
+++ b/integration-tests/backend/test_flow_multitenancy.go
@@ -147,17 +147,17 @@ var _ = g.Describe("[sig-netobserv] Network_Observability Multi-Tenancy", g.Orde
 
 		g.By("Create secret-watcher RoleBinding in LokiStack namespace")
 		createSecretWatcherRB(lokiStackNS)
-	})
 
-	g.AfterAll(func() {
-		if ls != nil {
-			ls.removeLokiStack()
-			ls.removeObjectStorage()
-		}
-		if !Lokiexisting {
-			LO.uninstallOperator()
-		}
-		deleteNamespace(lokiStackNS)
+		g.DeferCleanup(func() {
+			if ls != nil {
+				ls.removeLokiStack()
+				ls.removeObjectStorage()
+			}
+			if !Lokiexisting {
+				LO.uninstallOperator()
+			}
+			deleteNamespace(lokiStackNS)
+		})
 	})
 
 	g.BeforeEach(func() {


### PR DESCRIPTION
## Description

[NETOBSERV-2949](https://redhat.atlassian.net/browse/NETOBSERV-2949) Fix/gcs bucket cleanup leak

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved integration-test cleanup reliability across Azure, Google Cloud, and S3-compatible storage.
  - Storage cleanup now retries transient failures with backoff and reports combined errors after all attempts.
  - Cleanup continues after individual object-deletion failures, allowing remaining items to be processed.
  - Cleanup warnings no longer necessarily stop test execution.
  - Multitenancy test resources now use staged deferred cleanup handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->