### PR TITLE
Fix unchecked TryDelete error returns in netpol reconcilers

### DIFF
--- a/internal/controller/consoleplugin/consoleplugin_static_reconciler.go
+++ b/internal/controller/consoleplugin/consoleplugin_static_reconciler.go
@@ -157,7 +157,9 @@ func (r *StaticReconciler) reconcileNetpol(ctx context.Context, desired *flowsla
 	}
 
 	if !flowslatest.ShouldInstallNetworkPolicy(desired.Spec.NetworkPolicy.Enable, cni) {
-		r.Managed.TryDelete(ctx, r.netpol)
+		if err := r.Managed.TryDelete(ctx, r.netpol); err != nil {
+			return err
+		}
 		return nil
 	}
 

--- a/internal/controller/static/operator_reconciler.go
+++ b/internal/controller/static/operator_reconciler.go
@@ -46,7 +46,9 @@ func (r *operatorReconciler) reconcileNetpol(ctx context.Context) error {
 
 	np := r.buildNetworkPolicy(cni)
 	if np == nil {
-		r.Managed.TryDelete(ctx, r.netpol)
+		if err := r.Managed.TryDelete(ctx, r.netpol); err != nil {
+			return err
+		}
 		return nil
 	}
 	nsname := helper.NamespacedName(np)


### PR DESCRIPTION


## Description

followup #2893


Handle the error returned by r.Managed.TryDelete(ctx, r.netpol) in two locations where it was previously discarded:
- consoleplugin/consoleplugin_static_reconciler.go:reconcileNetpol
- static/operator_reconciler.go:reconcileNetpol

## Dependencies
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [X] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when removing network policies that are no longer required.
  * Reconciliation now reports deletion failures instead of silently continuing, helping surface configuration issues promptly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->