### PR TITLE
Agents: reminder for commit trailer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,7 +244,7 @@ Before commit:
 2. `make build lint test`
 3. `make update-bundle` (if CRD/CSV changed)
 4. Update docs
-5. Conventional commit messages
+5. Conventional commit messages, including an "Assisted-by:" or "Co-authored-by:" trailer with the model used. If the human plans to commit themselves, agents should remind them to add this trailer early (right after proposing code changes, once per conversation) rather than waiting for a final commit step that may never be reached.
 
 ## Resources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,7 +244,7 @@ Before commit:
 2. `make build lint test`
 3. `make update-bundle` (if CRD/CSV changed)
 4. Update docs
-5. Conventional commit messages, including an "Assisted-by:" or "Co-authored-by:" trailer with the model used. If the human plans to commit themselves, agents should remind them to add this trailer early (right after proposing code changes, once per conversation) rather than waiting for a final commit step that may never be reached.
+5. Conventional commit messages. Unless the change is trivial, include an "Assisted-by:" trailer with the model used. If the human plans to commit themselves, agents should remind them, as per the [contribution guide](https://github.com/netobserv/documents/blob/main/CONTRIBUTING.md), to consider adding this trailer when they commit. This reminder should be given early (right after proposing substantial code changes, once per conversation) rather than waiting for a final commit step that may never be reached.
 
 ## Resources
 


### PR DESCRIPTION
Make the agent themselves aware of our contributing guide regarding commit trailers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised the Contribution Checklist to require an `Assisted-by:` trailer identifying the model used for non-trivial changes.
  * Removed the previous equivalence with `Co-authored-by:`.
  * Added guidance for agents to remind contributors early—once per conversation—to consider including the trailer when committing substantial changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->