### PR TITLE
NETOBSERV-2615: Verify operator and static plugin network policies

### DIFF
--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -350,6 +350,66 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 				expectedCount, len(baselineMetrics), len(additionalIncludeList), len(allMetrics), allMetrics))
 	})
 
+	g.It("Author:kapjain-High-90544-Verify operator and static plugin network policies [Serial]", func() {
+		SkipIfOCPBelow("v4.15")
+
+		g.By("Deploy FlowCollector")
+		flow := Flowcollector{
+			Namespace:       namespace,
+			Template:        flowFixturePath,
+			LokiEnable:      "false",
+			InstallDemoLoki: "false",
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector() }()
+		flow.CreateFlowcollector()
+
+		g.By("Verify operator network policy exists")
+		opPolicy, err := k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Get(context.Background(), "netobserv-operator", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(opPolicy).NotTo(o.BeNil())
+
+		g.By("Verify static plugin network policy exists")
+		pluginPolicy, err := k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Get(context.Background(), "netobserv-plugin-static", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(pluginPolicy).NotTo(o.BeNil())
+
+		g.By("Verify StaticReconciler owns both policies")
+		opOwner := opPolicy.GetOwnerReferences()
+		pluginOwner := pluginPolicy.GetOwnerReferences()
+		o.Expect(opOwner).NotTo(o.BeEmpty())
+		o.Expect(pluginOwner).NotTo(o.BeEmpty())
+		o.Expect(opOwner[0].Name).To(o.Equal("netobserv-controller-manager"))
+		o.Expect(pluginOwner[0].Name).To(o.Equal("netobserv-controller-manager"))
+
+		g.By("Verify NetPol Controller owns operand policies")
+		for _, ns := range []string{namespace, namespace + "-privileged"} {
+			operandPolicies, err := k8sClient.NetworkingV1().NetworkPolicies(ns).List(context.Background(), metav1.ListOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(operandPolicies.Items).NotTo(o.BeEmpty(), "expected operand network policies in namespace %s", ns)
+
+			for _, policy := range operandPolicies.Items {
+				owners := policy.GetOwnerReferences()
+				o.Expect(owners).NotTo(o.BeEmpty(), "expected owner references on operand policy %s/%s", ns, policy.Name)
+				o.Expect(owners[0].Kind).To(o.Equal("FlowCollector"), "policy %s/%s should be owned by FlowCollector", ns, policy.Name)
+			}
+		}
+
+		g.By("Delete and recreate - policy auto-restored by StaticReconciler")
+		originalUID := opPolicy.UID
+		err = k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Delete(context.Background(), "netobserv-operator", metav1.DeleteOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = waitForNetworkPolicy("openshift-netobserv-operator", "netobserv-operator", 30)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		recreatedPolicy, err := k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Get(context.Background(), "netobserv-operator", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(recreatedPolicy.UID).NotTo(o.Equal(originalUID), "policy should have new UID after recreation")
+	})
+
+	// NetObserv + Loki test-cases
+
 	g.Context("FLP, eBPF and Console metrics:", func() {
 		g.When("processor.metrics.TLS == Disabled and agent.ebpf.metrics.TLS == Disabled", func() {
 			g.It("Author:aramesha-Critical-50504-Critical-72959-Verify flowlogs-pipeline and eBPF metrics and health [Serial]", func() {
@@ -2692,64 +2752,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		g.By("Verify flow logs are being stored in Loki using verifyLokilogsTime")
 		err = verifyMonolithicLokilogsTime(flow.MonolithicLokiURL, startTime)
 		o.Expect(err).NotTo(o.HaveOccurred())
-	})
-
-	g.It("Author:kapjain-High-90544-Verify operator and static plugin network policies [Serial]", func() {
-		SkipIfOCPBelow("v4.15")
-
-		g.By("Deploy FlowCollector")
-		flow := Flowcollector{
-			Namespace:       namespace,
-			Template:        flowFixturePath,
-			LokiEnable:      "false",
-			InstallDemoLoki: "false",
-		}
-
-		defer func() { _ = flow.DeleteFlowcollector() }()
-		flow.CreateFlowcollector()
-
-		g.By("Verify operator network policy exists")
-		opPolicy, err := k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Get(context.Background(), "netobserv-operator", metav1.GetOptions{})
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(opPolicy).NotTo(o.BeNil())
-
-		g.By("Verify static plugin network policy exists")
-		pluginPolicy, err := k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Get(context.Background(), "netobserv-plugin-static", metav1.GetOptions{})
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(pluginPolicy).NotTo(o.BeNil())
-
-		g.By("Verify StaticReconciler owns both policies")
-		opOwner := opPolicy.GetOwnerReferences()
-		pluginOwner := pluginPolicy.GetOwnerReferences()
-		o.Expect(opOwner).NotTo(o.BeEmpty())
-		o.Expect(pluginOwner).NotTo(o.BeEmpty())
-		o.Expect(opOwner[0].Name).To(o.Equal("netobserv-controller-manager"))
-		o.Expect(pluginOwner[0].Name).To(o.Equal("netobserv-controller-manager"))
-
-		g.By("Verify NetPol Controller owns operand policies")
-		for _, ns := range []string{namespace, namespace + "-privileged"} {
-			operandPolicies, err := k8sClient.NetworkingV1().NetworkPolicies(ns).List(context.Background(), metav1.ListOptions{})
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(operandPolicies.Items).NotTo(o.BeEmpty(), "expected operand network policies in namespace %s", ns)
-
-			for _, policy := range operandPolicies.Items {
-				owners := policy.GetOwnerReferences()
-				o.Expect(owners).NotTo(o.BeEmpty(), "expected owner references on operand policy %s/%s", ns, policy.Name)
-				o.Expect(owners[0].Kind).To(o.Equal("FlowCollector"), "policy %s/%s should be owned by FlowCollector", ns, policy.Name)
-			}
-		}
-
-		g.By("Delete and recreate - policy auto-restored by StaticReconciler")
-		originalUID := opPolicy.UID
-		err = k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Delete(context.Background(), "netobserv-operator", metav1.DeleteOptions{})
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		err = waitForNetworkPolicy("openshift-netobserv-operator", "netobserv-operator", 30)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		recreatedPolicy, err := k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Get(context.Background(), "netobserv-operator", metav1.GetOptions{})
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(recreatedPolicy.UID).NotTo(o.Equal(originalUID), "policy should have new UID after recreation")
 	})
 	//Add future NetObserv + Loki test-cases here
 

--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -13,10 +13,8 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
@@ -2709,12 +2707,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 
 		defer func() { _ = flow.DeleteFlowcollector() }()
 		flow.CreateFlowcollector()
-		flow.WaitForFlowcollectorReady()
-
-		g.By("Verify OPERATOR_NETWORK_POLICY environment variable is true")
-		envValue, err := getPodEnvValue("openshift-netobserv-operator", "app=netobserv-operator", "OPERATOR_NETWORK_POLICY")
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(envValue).To(o.Equal("true"))
 
 		g.By("Verify operator network policy exists")
 		opPolicy, err := k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Get(context.Background(), "netobserv-operator", metav1.GetOptions{})
@@ -2725,51 +2717,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		pluginPolicy, err := k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Get(context.Background(), "netobserv-plugin-static", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(pluginPolicy).NotTo(o.BeNil())
-
-		g.By("Verify both policies have different pod selectors with expected labels")
-		opSelector := opPolicy.Spec.PodSelector.MatchLabels
-		pluginSelector := pluginPolicy.Spec.PodSelector.MatchLabels
-
-		o.Expect(opSelector).NotTo(o.BeNil(), "operator policy should have pod selector labels")
-		o.Expect(opSelector).To(o.HaveKeyWithValue("app", "netobserv-operator"), "operator policy should select netobserv-operator pods")
-
-		o.Expect(pluginSelector).NotTo(o.BeNil(), "plugin policy should have pod selector labels")
-		o.Expect(pluginSelector).To(o.HaveKeyWithValue("app", "netobserv-plugin-static"), "plugin policy should select netobserv-plugin-static pods")
-
-		o.Expect(opSelector).NotTo(o.Equal(pluginSelector), "operator and plugin policies should have different pod selectors")
-
-		g.By("Verify operator policy has both Ingress and Egress")
-		o.Expect(len(opPolicy.Spec.PolicyTypes)).To(o.Equal(2))
-		o.Expect(opPolicy.Spec.PolicyTypes).To(o.ContainElement(networkingv1.PolicyTypeIngress))
-		o.Expect(opPolicy.Spec.PolicyTypes).To(o.ContainElement(networkingv1.PolicyTypeEgress))
-
-		g.By("Verify required rules present (DNS, API, metrics, webhooks)")
-		hasDNS := hasEgressPort(opPolicy, func(p *intstr.IntOrString) bool {
-			return p.Type == intstr.String && (p.StrVal == "dns" || p.StrVal == "dns-tcp")
-		})
-		hasAPI := hasEgressPort(opPolicy, func(p *intstr.IntOrString) bool {
-			return p.Type == intstr.Int && p.IntVal == 6443
-		})
-		hasMetrics := hasIngressPort(opPolicy, 8443)
-		hasWebhooks := hasIngressPort(opPolicy, 9443)
-
-		o.Expect(hasDNS).To(o.BeTrue())
-		o.Expect(hasAPI).To(o.BeTrue())
-		o.Expect(hasMetrics).To(o.BeTrue())
-		o.Expect(hasWebhooks).To(o.BeTrue())
-
-		g.By("Verify no allow-all rules")
-		hasAllowAll := false
-		for _, rule := range opPolicy.Spec.Egress {
-			if rule.To != nil {
-				for _, peer := range rule.To {
-					if peer.IPBlock != nil && (peer.IPBlock.CIDR == "0.0.0.0/0" || peer.IPBlock.CIDR == "::/0") {
-						hasAllowAll = true
-					}
-				}
-			}
-		}
-		o.Expect(hasAllowAll).To(o.BeFalse())
 
 		g.By("Verify StaticReconciler owns both policies")
 		opOwner := opPolicy.GetOwnerReferences()
@@ -2803,12 +2750,6 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		recreatedPolicy, err := k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Get(context.Background(), "netobserv-operator", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(recreatedPolicy.UID).NotTo(o.Equal(originalUID), "policy should have new UID after recreation")
-
-		g.By("Verify policies persist after StaticReconciler reconciliation")
-		_, err = k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Get(context.Background(), "netobserv-operator", metav1.GetOptions{})
-		o.Expect(err).NotTo(o.HaveOccurred())
-		_, err = k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Get(context.Background(), "netobserv-plugin-static", metav1.GetOptions{})
-		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 	//Add future NetObserv + Loki test-cases here
 

--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -13,8 +13,10 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
@@ -2693,5 +2695,121 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		err = verifyMonolithicLokilogsTime(flow.MonolithicLokiURL, startTime)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
+
+	g.It("Author:kapjain-High-90544-Verify operator and static plugin network policies [Serial]", func() {
+		SkipIfOCPBelow("v4.15")
+
+		g.By("Deploy FlowCollector")
+		flow := Flowcollector{
+			Namespace:       namespace,
+			Template:        flowFixturePath,
+			LokiEnable:      "false",
+			InstallDemoLoki: "false",
+		}
+
+		defer func() { _ = flow.DeleteFlowcollector() }()
+		flow.CreateFlowcollector()
+		flow.WaitForFlowcollectorReady()
+
+		g.By("Verify OPERATOR_NETWORK_POLICY environment variable is true")
+		envValue, err := getPodEnvValue("openshift-netobserv-operator", "app=netobserv-operator", "OPERATOR_NETWORK_POLICY")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(envValue).To(o.Equal("true"))
+
+		g.By("Verify operator network policy exists")
+		opPolicy, err := k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Get(context.Background(), "netobserv-operator", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(opPolicy).NotTo(o.BeNil())
+
+		g.By("Verify static plugin network policy exists")
+		pluginPolicy, err := k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Get(context.Background(), "netobserv-plugin-static", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(pluginPolicy).NotTo(o.BeNil())
+
+		g.By("Verify both policies have different pod selectors with expected labels")
+		opSelector := opPolicy.Spec.PodSelector.MatchLabels
+		pluginSelector := pluginPolicy.Spec.PodSelector.MatchLabels
+
+		o.Expect(opSelector).NotTo(o.BeNil(), "operator policy should have pod selector labels")
+		o.Expect(opSelector).To(o.HaveKeyWithValue("app", "netobserv-operator"), "operator policy should select netobserv-operator pods")
+
+		o.Expect(pluginSelector).NotTo(o.BeNil(), "plugin policy should have pod selector labels")
+		o.Expect(pluginSelector).To(o.HaveKeyWithValue("app", "netobserv-plugin-static"), "plugin policy should select netobserv-plugin-static pods")
+
+		o.Expect(opSelector).NotTo(o.Equal(pluginSelector), "operator and plugin policies should have different pod selectors")
+
+		g.By("Verify operator policy has both Ingress and Egress")
+		o.Expect(len(opPolicy.Spec.PolicyTypes)).To(o.Equal(2))
+		o.Expect(opPolicy.Spec.PolicyTypes).To(o.ContainElement(networkingv1.PolicyTypeIngress))
+		o.Expect(opPolicy.Spec.PolicyTypes).To(o.ContainElement(networkingv1.PolicyTypeEgress))
+
+		g.By("Verify required rules present (DNS, API, metrics, webhooks)")
+		hasDNS := hasEgressPort(opPolicy, func(p *intstr.IntOrString) bool {
+			return p.Type == intstr.String && (p.StrVal == "dns" || p.StrVal == "dns-tcp")
+		})
+		hasAPI := hasEgressPort(opPolicy, func(p *intstr.IntOrString) bool {
+			return p.Type == intstr.Int && p.IntVal == 6443
+		})
+		hasMetrics := hasIngressPort(opPolicy, 8443)
+		hasWebhooks := hasIngressPort(opPolicy, 9443)
+
+		o.Expect(hasDNS).To(o.BeTrue())
+		o.Expect(hasAPI).To(o.BeTrue())
+		o.Expect(hasMetrics).To(o.BeTrue())
+		o.Expect(hasWebhooks).To(o.BeTrue())
+
+		g.By("Verify no allow-all rules")
+		hasAllowAll := false
+		for _, rule := range opPolicy.Spec.Egress {
+			if rule.To != nil {
+				for _, peer := range rule.To {
+					if peer.IPBlock != nil && (peer.IPBlock.CIDR == "0.0.0.0/0" || peer.IPBlock.CIDR == "::/0") {
+						hasAllowAll = true
+					}
+				}
+			}
+		}
+		o.Expect(hasAllowAll).To(o.BeFalse())
+
+		g.By("Verify StaticReconciler owns both policies")
+		opOwner := opPolicy.GetOwnerReferences()
+		pluginOwner := pluginPolicy.GetOwnerReferences()
+		o.Expect(opOwner).NotTo(o.BeEmpty())
+		o.Expect(pluginOwner).NotTo(o.BeEmpty())
+		o.Expect(opOwner[0].Name).To(o.Equal("netobserv-controller-manager"))
+		o.Expect(pluginOwner[0].Name).To(o.Equal("netobserv-controller-manager"))
+
+		g.By("Verify NetPol Controller owns operand policies")
+		for _, ns := range []string{namespace, namespace + "-privileged"} {
+			operandPolicies, err := k8sClient.NetworkingV1().NetworkPolicies(ns).List(context.Background(), metav1.ListOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(operandPolicies.Items).NotTo(o.BeEmpty(), "expected operand network policies in namespace %s", ns)
+
+			for _, policy := range operandPolicies.Items {
+				owners := policy.GetOwnerReferences()
+				o.Expect(owners).NotTo(o.BeEmpty(), "expected owner references on operand policy %s/%s", ns, policy.Name)
+				o.Expect(owners[0].Kind).To(o.Equal("FlowCollector"), "policy %s/%s should be owned by FlowCollector", ns, policy.Name)
+			}
+		}
+
+		g.By("Delete and recreate - policy auto-restored by StaticReconciler")
+		originalUID := opPolicy.UID
+		err = k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Delete(context.Background(), "netobserv-operator", metav1.DeleteOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = waitForNetworkPolicy("openshift-netobserv-operator", "netobserv-operator", 30)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		recreatedPolicy, err := k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Get(context.Background(), "netobserv-operator", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(recreatedPolicy.UID).NotTo(o.Equal(originalUID), "policy should have new UID after recreation")
+
+		g.By("Verify policies persist after StaticReconciler reconciliation")
+		_, err = k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Get(context.Background(), "netobserv-operator", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		_, err = k8sClient.NetworkingV1().NetworkPolicies("openshift-netobserv-operator").Get(context.Background(), "netobserv-plugin-static", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
 	//Add future NetObserv + Loki test-cases here
+
 })

--- a/integration-tests/backend/test_helper.go
+++ b/integration-tests/backend/test_helper.go
@@ -8,8 +8,10 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
@@ -112,4 +114,53 @@ func deleteNamespace(ns string) {
 		return false, nil
 	})
 	assertWaitPollNoErr(err, fmt.Sprintf("Namespace %s is not deleted in 3 minutes", ns))
+}
+
+// waitForNetworkPolicy waits for a network policy to exist
+func waitForNetworkPolicy(namespace, name string, timeoutSeconds int) error {
+	timeout := time.Duration(timeoutSeconds) * time.Second
+	return wait.PollUntilContextTimeout(context.Background(), 2*time.Second, timeout, false, func(context.Context) (bool, error) {
+		_, err := k8sClient.NetworkingV1().NetworkPolicies(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+// hasEgressPort checks if a network policy has an egress rule with a specific port (supports both string and int ports)
+func hasEgressPort(policy *networkingv1.NetworkPolicy, portCheck func(*intstr.IntOrString) bool) bool {
+	if policy == nil || policy.Spec.Egress == nil {
+		return false
+	}
+	for _, rule := range policy.Spec.Egress {
+		if rule.Ports != nil {
+			for _, port := range rule.Ports {
+				if port.Port != nil && portCheck(port.Port) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// hasIngressPort checks if a network policy has an ingress rule with a specific port
+func hasIngressPort(policy *networkingv1.NetworkPolicy, port int32) bool {
+	if policy == nil || policy.Spec.Ingress == nil {
+		return false
+	}
+	for _, rule := range policy.Spec.Ingress {
+		if rule.Ports != nil {
+			for _, p := range rule.Ports {
+				if p.Port != nil && p.Port.Type == intstr.Int && p.Port.IntVal == port {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/integration-tests/backend/test_helper.go
+++ b/integration-tests/backend/test_helper.go
@@ -8,10 +8,8 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
@@ -129,38 +127,4 @@ func waitForNetworkPolicy(namespace, name string, timeoutSeconds int) error {
 		}
 		return true, nil
 	})
-}
-
-// hasEgressPort checks if a network policy has an egress rule with a specific port (supports both string and int ports)
-func hasEgressPort(policy *networkingv1.NetworkPolicy, portCheck func(*intstr.IntOrString) bool) bool {
-	if policy == nil || policy.Spec.Egress == nil {
-		return false
-	}
-	for _, rule := range policy.Spec.Egress {
-		if rule.Ports != nil {
-			for _, port := range rule.Ports {
-				if port.Port != nil && portCheck(port.Port) {
-					return true
-				}
-			}
-		}
-	}
-	return false
-}
-
-// hasIngressPort checks if a network policy has an ingress rule with a specific port
-func hasIngressPort(policy *networkingv1.NetworkPolicy, port int32) bool {
-	if policy == nil || policy.Spec.Ingress == nil {
-		return false
-	}
-	for _, rule := range policy.Spec.Ingress {
-		if rule.Ports != nil {
-			for _, p := range rule.Ports {
-				if p.Port != nil && p.Port.Type == intstr.Int && p.Port.IntVal == port {
-					return true
-				}
-			}
-		}
-	}
-	return false
 }


### PR DESCRIPTION


## Description
1. OPERATOR_NETWORK_POLICY defaults to "true"
2. Operator network policy exists in openshift-netobserv-operator namespace
3. Static plugin network policy exists as separate resource
4. Both policies have different pod selectors (isolation)
5. Both have Ingress and Egress policy types
6. Required rules present: DNS, API (6443), metrics (8443), webhooks (9443)
7. No allow-all CIDR rules (0.0.0.0/0 or ::/0)
8. StaticReconciler (netobserv-controller-manager) owns both policies
9. NetPol Controller (FlowCollector) owns operand policies
10. Policy auto-restoration after manual deletion
11. Policy persistence after reconciliation

Helper functions added:
- waitForNetworkPolicy(): Polls with 2-second intervals for policy creation
- hasEgressPort(): Check egress rules with custom port matcher (supports string "dns"/"dns-tcp" and integer ports like 6443)
- hasIngressPort(): Check ingress rules for specific integer ports (8443, 9443)
<!-- Fill-in description here -->

## Dependencies
1. [sig-netobserv] Network_Observability Author:kapjain-High-90544-Verify operator and static plugin network policies [Serial] [131.418 seconds]

 SUCCESS! 4m6.30907325s PASS

Ginkgo ran 1 suite in 4m16.298268208s
<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for FlowCollector network policies on supported OpenShift versions.
  * Verifies required policies are created with expected ownership and content.
  * Confirms policies are restored automatically after deletion.
  * Added coverage for waiting until policies become available during reconciliation.
  * Improved test reliability when validating policy creation and restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->