### PR TITLE
Add networkPolicy to gvrMap

### DIFF
--- a/integration-tests/backend/k8s_client.go
+++ b/integration-tests/backend/k8s_client.go
@@ -106,6 +106,7 @@ var gvrMap = map[string]schema.GroupVersionResource{
 	// Network Policy (AdminNetworkPolicy)
 	"adminnetworkpolicy":         {Group: "policy.networking.k8s.io", Version: "v1alpha1", Resource: "adminnetworkpolicies"},
 	"baselineadminnetworkpolicy": {Group: "policy.networking.k8s.io", Version: "v1alpha1", Resource: "baselineadminnetworkpolicies"},
+	"networkPolicy":              {Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"},
 
 	// User-defined networks (OVN)
 	"userdefinednetwork":        {Group: "k8s.ovn.org", Version: "v1", Resource: "userdefinednetworks"},

--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -1649,7 +1649,7 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 		netpolTemplate := filePath.Join(baseDir, "networking", "networkPolicy.yaml")
 		netpolName := "allow-ingress"
 		netPolParameters := []string{"--ignore-unknown-parameters=true", "-p", "NAME=" + netpolName, "SERVER_NS=" + testClient1Template.ServerNS, "ALLOW_NS=" + testClient1Template.ClientNS, "-f", netpolTemplate}
-		defer deleteResource("netpol", netpolName, testClient1Template.ServerNS)
+		defer deleteResource("networkPolicy", netpolName, testClient1Template.ServerNS)
 		err = applyResourceFromTemplateByAdmin(netPolParameters...)
 		o.Expect(err).NotTo(o.HaveOccurred())
 


### PR DESCRIPTION
## Description

Missed adding networkPolicy to gvrMap in https://github.com/netobserv/netobserv-operator/pull/2911

## Dependencies

n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved integration test support for Kubernetes NetworkPolicy resources.
  - Corrected cleanup handling for NetworkPolicy resources in network policy correlation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->