### PR TITLE
(trivial) bump envtest 1.34

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ endif
 IMAGE ?= $(IMAGE_TAG_BASE):$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 # When updating, update also SetupKubeBuilderAssets in internal/pkg/test/envtest.go
-ENVTEST_K8S_VERSION = 1.23
+ENVTEST_K8S_VERSION = 1.34
 GOLANGCI_LINT_VERSION = v2.12.2
 CRDOC_VERSION = 0.6.4
 

--- a/internal/pkg/test/envtest.go
+++ b/internal/pkg/test/envtest.go
@@ -85,7 +85,7 @@ func SetupKubeBuilderAssets() error {
 	root := RepoRoot()
 	// Calling setup-envtest which should be in this repo ./bin - if that's not the case, just run `make envtest` once and it should be downloaded.
 	// Make sure to always keep the version in sync with ENVTEST_K8S_VERSION in the Makefile.
-	out, err := exec.Command(filepath.Join(root, "bin", "setup-envtest"), "use", "1.23", "-p", "path").Output()
+	out, err := exec.Command(filepath.Join(root, "bin", "setup-envtest"), "use", "1.34", "-p", "path").Output()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test environment configuration to use Kubernetes version 1.34 assets, improving compatibility with the current test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->