### PR TITLE
[NETOBSERV-2996] new policy added for netbserv operator and static plugin

### DIFF
--- a/integration-tests/backend/test_flowcollector.go
+++ b/integration-tests/backend/test_flowcollector.go
@@ -2382,13 +2382,17 @@ var _ = g.Describe("[sig-netobserv] Network_Observability", func() {
 			"service/loki",
 			"deployment.apps/loki",
 			"configmap/loki-config",
+			"serviceaccount/netobserv-ebpf-agent",
 		}
 		// Static plugin and network policy are only available on OCP 4.15+
 		if IsOCPVersionAtLeast("v4.15") {
 			componentsShouldRemain = append(componentsShouldRemain,
 				"deployment.apps/netobserv-plugin-static",
 				"service/netobserv-plugin-static",
+				"serviceaccount/netobserv-plugin-static",
 				"networkpolicy.networking.k8s.io/netobserv",
+				"networkpolicy.networking.k8s.io/netobserv-operator",
+				"networkpolicy.networking.k8s.io/netobserv-plugin-static",
 			)
 		}
 


### PR DESCRIPTION
## Description

new service account and policy added for netbserv operator and static pluginand should not deleted when on pause so added in the list.

<!-- Fill-in description here -->
1. [sig-netobserv] Network_Observability Author:kapjain-Medium-88334-Pause Network Observability functions [Serial] [285.540 seconds]

 SUCCESS! 5m24.333529833s PASS

Ginkgo ran 1 suite in 5m38.679599917s
Test Suite Passed
## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end coverage for paused network observability deployments.
  * Verification now confirms required service accounts and network policies remain available, including additional resources on newer platform versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->