### PR TITLE
NETOBSERV-2993: Add retry mechanism for namespace deletion webhook timeouts

### DIFF
--- a/integration-tests/backend/test_helper.go
+++ b/integration-tests/backend/test_helper.go
@@ -140,7 +140,7 @@ func isWebhookTimeoutError(err error) bool {
 	if err == nil {
 		return false
 	}
-	errMsg := err.Error()
+	errMsg := strings.ToLower(err.Error())
 	return strings.Contains(errMsg, "webhook") &&
 		(strings.Contains(errMsg, "timeout") ||
 			strings.Contains(errMsg, "deadline exceeded"))

--- a/integration-tests/backend/test_helper.go
+++ b/integration-tests/backend/test_helper.go
@@ -3,6 +3,7 @@ package e2etests
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -93,15 +94,35 @@ func deleteNamespace(ns string) {
 		return
 	}
 
-	err := k8sClient.CoreV1().Namespaces().Delete(context.Background(), ns, metav1.DeleteOptions{})
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			o.Expect(err).NotTo(o.HaveOccurred())
+	// Try delete with retry on webhook timeout
+	maxRetries := 3
+	var deleteErr error
+	for i := 0; i < maxRetries; i++ {
+		deleteErr = k8sClient.CoreV1().Namespaces().Delete(context.Background(), ns, metav1.DeleteOptions{})
+		if deleteErr != nil {
+			if apierrors.IsNotFound(deleteErr) {
+				return // Already deleted
+			}
+			if isWebhookTimeoutError(deleteErr) && i < maxRetries-1 {
+				e2e.Logf("Webhook timeout deleting namespace %s (attempt %d/%d), retrying in 10s...", ns, i+1, maxRetries)
+				time.Sleep(10 * time.Second) // Wait before retry
+				continue
+			}
+			if !isWebhookTimeoutError(deleteErr) {
+				o.Expect(deleteErr).NotTo(o.HaveOccurred())
+				return
+			}
+		} else {
+			break // Success
 		}
-		return
 	}
 
-	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 180*time.Second, false, func(context.Context) (bool, error) {
+	// If all retries failed with webhook timeout, log but continue to verify deletion
+	if deleteErr != nil && isWebhookTimeoutError(deleteErr) {
+		e2e.Logf("Warning: All %d attempts to delete namespace %s failed with webhook timeout, checking if deletion succeeded anyway", maxRetries, ns)
+	}
+
+	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 180*time.Second, false, func(context.Context) (bool, error) {
 		_, getErr := k8sClient.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{})
 		if getErr != nil {
 			if apierrors.IsNotFound(getErr) {
@@ -112,4 +133,15 @@ func deleteNamespace(ns string) {
 		return false, nil
 	})
 	assertWaitPollNoErr(err, fmt.Sprintf("Namespace %s is not deleted in 3 minutes", ns))
+}
+
+// isWebhookTimeoutError checks if the error is a webhook timeout error
+func isWebhookTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errMsg := err.Error()
+	return strings.Contains(errMsg, "webhook") &&
+		(strings.Contains(errMsg, "timeout") ||
+			strings.Contains(errMsg, "deadline exceeded"))
 }


### PR DESCRIPTION
## Description

Fixes flaky test failures in periodic CI caused by CNV (OpenShift Virtualization) webhook timeouts during namespace cleanup.

### Problem

The `Author:aramesha-High-85935-Validate CUDN with Localnet and VM's` integration test was failing intermittently in periodic runs with:
```
failed calling webhook "mutate-ns-hco.kubevirt.io": 
Post "https://hco-webhook-service.openshift-cnv.svc:4343/mutate-ns-hco-kubevirt-io?timeout=10s": 
context deadline exceeded
```

This error occurred during AfterAll cleanup when deleting namespaces containing VMs. The actual test validation passed successfully (8 flow records found) - the failure was purely in the cleanup phase.

### Solution

Added resilience to namespace deletion in `integration-tests/backend/test_helper.go`:

1. **Webhook timeout detection**: Added `isWebhookTimeoutError()` helper to identify webhook timeout errors
2. **Retry mechanism**: Retry namespace deletion up to 3 times with 10-second delays when webhook timeouts occur
3. **Graceful handling**: Continue to verify namespace deletion even after webhook errors

## Dependencies
n/a

## Checklist

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ] No special configuration needed - standard integration test environment with CNV operator
* [ ] I have added thorough unit tests for the change.
   * N/A - This is a test infrastructure improvement. The fix was validated by re-running the previously failing integration test.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [x] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Test Results

PASSED TESTS (4):
----------------------------------------------------------------------------------------------------------
1. [sig-netobserv] Network_Observability Author:aramesha-High-83022-Validate CUDN with Localnet [Serial] [384.066 seconds]
2. [sig-netobserv] Network_Observability with VMs Author:aramesha-NonPreRelease-Longduration-High-76537-Verify flow enrichment for VM's secondary interfaces [Disruptive][Slow] [669.400 seconds]
3. [sig-netobserv] Network_Observability with VMs Author:aramesha-NonPreRelease-Longduration-Medium-85887-Verify UDN with VMs [Disruptive][Slow] [347.571 seconds]
4. [sig-netobserv] Network_Observability with VMs Author:aramesha-High-85935-Validate CUDN with Localnet and VM's[Serial] [568.665 seconds]

 SUCCESS! 33m33.928847007s --- PASS: TestBackend (2013.93s)
PASS
ok    e2etests        2016.189s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup reliability when namespace or network policy operations encounter webhook timeouts or exceeded deadlines.
  - Cleanup requests now stop promptly when their configured wait period expires, preventing stalled operations.
  - Refined webhook timeout detection to avoid treating unrelated webhook errors as timeouts.
  - Deletion attempts continue to retry and confirm namespace removal, reducing the risk of incomplete cleanup during transient failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->